### PR TITLE
Remove 'Removing RSSMii' entry in the site navigation page.

### DIFF
--- a/_pages/en_US/site-navigation.md
+++ b/_pages/en_US/site-navigation.md
@@ -60,7 +60,6 @@ sitemap: false
 + [Nintendont](nintendont)
 + [Playing Wii Game Mods](riivolution)
 + [Recommended Homebrew](recommended-homebrew)
-+ [Removing RSSMii](rssmii-remove)
 + [USB Loaders](usb-loaders)
 + [Using SysCheck](syscheck)
 + [Wii Backup Manager](wiibackupmanager)


### PR DESCRIPTION
**Description**

The `Removing RSSMii` page does not exist. Removal instructions have been moved to the main RSSMii page. This commit updates the entry to point to the removal instructions on that page.

<!--What does this pull request do? Why is it needed?-->
