### PR TITLE
treewide: eradicate image alternative names

### DIFF
--- a/_pages/en_US/404.md
+++ b/_pages/en_US/404.md
@@ -3,7 +3,7 @@ title: "Page Not Found"
 sitemap: false
 ---
 
-![404](/images/main-pages/Wii_Red_404.jpg)
+![](/images/main-pages/Wii_Red_404.jpg)
 
 Sorry, but the page you were trying to view does not exist.
 {: .notice--warning}

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -48,7 +48,7 @@ Make sure that the console is close to the computer running the exploit, ideally
 1. Take note in the top right corner of the letter next to the system version.
     + This letter corresponds to your system menu region, which you will need to know for the corresponding steps.
 
-    ![Wii Region](/images/wii/SystemMenuVersion.png)
+    ![](/images/wii/SystemMenuVersion.png)
 
 1. Power off your console.
 1. Start your Linux distro, and ensure you are connected to the internet.

--- a/_pages/en_US/bootmii.md
+++ b/_pages/en_US/bootmii.md
@@ -34,26 +34,26 @@ If you have BootMii installed as boot2, you will need to launch BootMii by resta
 1. Launch the Homebrew Channel.
 1. Press the HOME Button, then select "Launch BootMii".
 
-    ![BootMii_Main](/images/bootmii/BootMii_Main.png)
+    ![](/images/bootmii/BootMii_Main.png)
 
 1. Select the Options button (the icon with the gears).
 
-    ![BootMii_Gears_Icon](/images/bootmii/BootMii_Gears_Icon.png)
+    ![](/images/bootmii/BootMii_Gears_Icon.png)
 
 1. Select the first button to the left.
     + A NAND backup will start. You can watch the progress on the screen.
     + "Bad Blocks" are normal, and mostly originate from the factory due to NAND binning. Don't worry when you see some on a NAND backup.
     + After this step, it will verify the backup. Ideally, all the blocks should be green after the verification process.
 
-    ![BootMii_Green_Arrow](/images/bootmii/BootMii_Green_Arrow.png)
+    ![](/images/bootmii/BootMii_Green_Arrow.png)
 
 1. When the process is complete, exit the NAND backup screen by pressing any button.
 
-    ![BootMii_NAND_Backup](/images/bootmii/BootMii_NAND_Backup.png)
+    ![](/images/bootmii/BootMii_NAND_Backup.png)
 
 1. Press the Back button (the one with an arrow), then press either the Wii Menu button or the Homebrew Channel button to exit BootMii.
 
-    ![BootMii_Return_Arrow](/images/bootmii/BootMii_Return_Arrow.png)
+    ![](/images/bootmii/BootMii_Return_Arrow.png)
 
 <div id="restore-notice" class="notice" markdown="1">
 Note: **restoring a NAND backup is usually a last resort**. There often better ways to unbrick your console.

--- a/_pages/en_US/bootmiirecover.md
+++ b/_pages/en_US/bootmiirecover.md
@@ -45,11 +45,11 @@ If you want to restore a game's save data, use Dolphin to import your NAND backu
 1. Press the HOME Button, then select "Launch BootMii".
 1. Select the Options button (the icon with the gears).
 
-    ![BootMii_Gears_Icon](/images/BootMii/BootMii_Gears_Icon.png)
+    ![](/images/BootMii/BootMii_Gears_Icon.png)
 
 1. Select the RestoreMii button.
 
-    ![BootMii_Red_Arrow](/images/BootMii/BootMii_Red_Arrow.png)
+    ![](/images/BootMii/BootMii_Red_Arrow.png)
 
 1. If BootMii is installed as IOS, input the Konami code on your GameCube controller: ↑, ↑, ↓, ↓, ←, →, ←, →, B, A, START
 1. After the recovery ended, you should see a text say `I HAZ SUCCESS!`, otherwise `I HAZ FAIL`. Hit any button on your Wii console or GCN controller.

--- a/_pages/en_US/bricks.md
+++ b/_pages/en_US/bricks.md
@@ -71,7 +71,7 @@ When navigating to Wii Settings, you instead get an error from the Opera web bro
 #### Cause
 A semibrick occurs when a different region Wii Menu or a different region custom theme is installed. As the Wii Settings menu is rendered using HTML pages with Opera, themes often replace these pages and put them in different directories; essentially leading to a `404 Not Found` error but in the form of a console brick.
 
-![Semibrick](/images/bricks/semibrick.png)
+![](/images/bricks/semibrick.png)
 
 #### Solutions
 Verify in AnyRegion Changer that your console region is the same as the theme or Wii Menu that you have installed.
@@ -90,7 +90,7 @@ If you are actually in the process of a region change, use [ARC-ME](https://gith
 #### Symptoms
 Attempt to start the Wii - warning/press A screen shows up, and when A is pressed, the screen passes normally; however, beyond this point, nothing happens and the Wii remains on a black screen. This happened after installing a WAD and rebooting, or returning to the Wii Menu. Alternatively, the Wii Menu can still be accessed, but opening the corrupt channel results in the console freezing. In some cases, you may see the "System files are corrupted" screen.
 
-![System files are corrupted](/images/bricks/sysfiles-corrupted.jpg)
+![](/images/bricks/sysfiles-corrupted.jpg)
 
 #### Cause
 Banner bricks occur if you install a WAD file that has an invalid Wii Menu banner or icon.
@@ -137,7 +137,7 @@ This brick is a more fatal version of a [Semibrick](#semibrick). If your SYSCONF
 
 However, the setup pages are in a similar location to the Wii settings pages. If you have an incorrect region Wii Menu or theme, the Wii cannot find them.
 
-![Wii menu brick](/images/bricks/sysmenu-brick.png)
+![](/images/bricks/sysmenu-brick.png)
 
 #### Solutions
 
@@ -155,7 +155,7 @@ Screen shows up as listed below on normal boot.
 `Error:003`<br>
 `unauthorized device has been detected.`<br>
 
-![Error 003](/images/bricks/error-003.png)
+![](/images/bricks/error-003.png)
 
 #### Cause
 When releasing the Korean Wiis, Nintendo changed the encryption key for these units specifically as a last ditch attempt at preventing homebrew. While obviously this failed, they also left a check in the System Menu versions 4.2/4.3 to determine whether or not the Korean Key is present on a system software region that is **not** Korean. If this check succeeds, the error triggers and the Wii is effectively bricked.

--- a/_pages/en_US/cios.md
+++ b/_pages/en_US/cios.md
@@ -45,7 +45,7 @@ If you are not on Windows, you may download & run [this script](/assets/files/d2
     + This must be the same device containing the d2x cIOS Installer.
 
 The WAD files should be on your SD card like this:
-![offline IOS files](/images/cios/d2x_offline_ios.png)
+![](/images/cios/d2x_offline_ios.png)
 {: .notice--info}
 
 #### Section II - Installing
@@ -73,7 +73,7 @@ On each cIOS that you try to install, you will first be shown a grid of active I
         Select cIOS version <65535>
         ```
 
-        ![Install cIOS 248](/images/cios/d2x_v11_248.png)
+        ![](/images/cios/d2x_v11_248.png)
 
     + cIOS 249 Installation
 
@@ -84,7 +84,7 @@ On each cIOS that you try to install, you will first be shown a grid of active I
         Select cIOS version <65535>
         ```
 
-        ![Install cIOS 249](/images/cios/d2x_v11_249.png)
+        ![](/images/cios/d2x_v11_249.png)
 
     + cIOS 250 Installation
 
@@ -95,7 +95,7 @@ On each cIOS that you try to install, you will first be shown a grid of active I
         Select cIOS version <65535>
         ```
 
-        ![Install cIOS 250](/images/cios/d2x_v11_250.png)
+        ![](/images/cios/d2x_v11_250.png)
 
     + cIOS 251 Installation
 
@@ -106,7 +106,7 @@ On each cIOS that you try to install, you will first be shown a grid of active I
         Select cIOS version <65535>
         ```
 
-        ![Install cIOS 251](/images/cios/d2x_v11_251.png)
+        ![](/images/cios/d2x_v11_251.png)
 
 Continue to [Open Shop Channel Installation](osc)
 Now that your Wii has adequate brick protection, you can install the Open Shop Channel, a trusted repository for homebrew that can be accessed both on and off the Wii.

--- a/_pages/en_US/dump-games.md
+++ b/_pages/en_US/dump-games.md
@@ -27,7 +27,7 @@ If you are dumping one of the 13 games on [this list](https://wiki.dolphin-emu.o
 1. Launch CleanRip from the list of homebrew.
 1. Select your device that you will be dumping the game to - a USB device or SD card.
 
-    ![Device type](/images/homebrew/CleanRip/2.png)
+    ![](/images/homebrew/CleanRip/2.png)
 
 1. When prompted, select `Yes` to download the redump.org DAT files.
     + This is required to ensure that the resulting dumps are clean/accurate.
@@ -35,20 +35,20 @@ If you are dumping one of the 13 games on [this list](https://wiki.dolphin-emu.o
     You may get an exception error if you do this. If so, simply skip and verify your dump on Dolphin Emulator if needed.
     {: .notice--warning}
 
-    ![DAT](/images/homebrew/CleanRip/3.png)
+    ![](/images/homebrew/CleanRip/3.png)
 
 1. Insert the game disc you would like to dump.
 
-    ![DVD](/images/homebrew/CleanRip/4.png)
+    ![](/images/homebrew/CleanRip/4.png)
 
 1. Set the settings as shown on the screen below, while verifying if your game disc is dual layer or not.
 
-    ![Settings](/images/homebrew/CleanRip/6.png)
+    ![](/images/homebrew/CleanRip/6.png)
 
 1. Press A to start dumping the disc.
     + This process can take quite some time, since it will dump the full 4.7 GB disc contents (8.5 GB for dual layer discs).
 
-    ![Copying](/images/homebrew/CleanRip/7.png)
+    ![](/images/homebrew/CleanRip/7.png)
 
 1. Proceed to [joining PART files](dump-games#joining-part-files-on-a-fat32-device).
 
@@ -75,21 +75,21 @@ Your Wii and your computer must be connected to the same local network.
 1. Press right on the D-pad, then press A.
 1. Choose the disc that you want to copy (The options are: `GameCube Disc`, `Wii Single-Layer Disc`, `Wii Dual-Layer Disc`) and press "A"
 
-    ![2](/images/homebrew/DumpDiscs_LAN/2.png)
+    ![](/images/homebrew/DumpDiscs_LAN/2.png)
 1. Insert the game disc into your Wii.
     + If it is already inserted, eject and reinsert the disc.
 
-    ![InsertTheDisc](/images/homebrew/DumpDiscs_LAN/insertthedisc.jpg)
+    ![](/images/homebrew/DumpDiscs_LAN/insertthedisc.jpg)
 1. Select the proper disc type.
 
-    ![3](/images/homebrew/DumpDiscs_LAN/3.png)
+    ![](/images/homebrew/DumpDiscs_LAN/3.png)
 1. Press any button to begin the dumping process.
 
-    ![4](/images/homebrew/DumpDiscs_LAN/4.png)
+    ![](/images/homebrew/DumpDiscs_LAN/4.png)
 1. Remember or write down your Wii's URL (IP address).
 1. On your computer, open the browser, go to your address bar and enter the Wii URL.
 
-    ![5](/images/homebrew/DumpDiscs_LAN/5.png)
+    ![](/images/homebrew/DumpDiscs_LAN/5.png)
 1. Click on `Click here to download XXXX.iso`.
 1. Proceed to [joining PART files](dump-games#joining-part-files-on-a-fat32-device).
 

--- a/_pages/en_US/dump-wads.md
+++ b/_pages/en_US/dump-wads.md
@@ -21,15 +21,15 @@ This guide will show you how to dump WADs from your Wii System Memory.
 1. Launch Yet Another BlueDump MOD from the list of homebrew.
 1. Press A.
 
-    ![Press A](/images/homebrew/DumpWADS/1.png)
+    ![](/images/homebrew/DumpWADS/1.png)
 
 1. Select `Installed Channel Titles`.
 
-    ![Installed Channel Titles](/images/homebrew/DumpWADS/2.png)
+    ![](/images/homebrew/DumpWADS/2.png)
 
 1. Find the content you want to dump and press the 1 Button.
 
-    ![Find channel](/images/homebrew/DumpWADS/3.png)
+    ![](/images/homebrew/DumpWADS/3.png)
 
 1. Select `Backup to WAD`.
 1. At the prompt to `Fakesign the ticket`, select `Yes`.
@@ -38,4 +38,4 @@ This guide will show you how to dump WADs from your Wii System Memory.
 
 The WAD has now been dumped, and should appear at the specified directory on your SD card.
 
-![Done](/images/homebrew/DumpWADS/4.png)
+![](/images/homebrew/DumpWADS/4.png)

--- a/_pages/en_US/flashhax.md
+++ b/_pages/en_US/flashhax.md
@@ -18,17 +18,17 @@ FlashHax is an exploit for the Wii that is triggered by using the Internet Chann
 1. Power on your console.
 1. Launch the Internet Channel.
 
-    ![Internet Channel Wii Menu](/images/exploits/flashhax/internet-channel-start.png)
+    ![](/images/exploits/flashhax/internet-channel-start.png)
 
 1. Go to `flashhax.com`.
 1. Select the correct region for your console.
 
-    ![Flashhax Region Select](/images/exploits/flashhax/select-region.png)
+    ![](/images/exploits/flashhax/select-region.png)
 
 1. Press the star button to open the bookmark tab.
 1. Select `Add Favorite`.
 
-    ![Bookmark Flashhax](/images/exploits/flashhax/bookmark-page.png)
+    ![](/images/exploits/flashhax/bookmark-page.png)
 
 
 #### Section II - FlashHax
@@ -37,7 +37,7 @@ FlashHax is an exploit for the Wii that is triggered by using the Internet Chann
 1. Wait a while
     + It may take some time as it is downloading the installer over the Internet.
 
-    ![Downloading Flashhax](/images/exploits/flashhax/wait-for-download.png)
+    ![](/images/exploits/flashhax/wait-for-download.png)
 
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
     + This may take multiple tries.

--- a/_pages/en_US/gcsaves.md
+++ b/_pages/en_US/gcsaves.md
@@ -36,19 +36,19 @@ If you are looking for save game exploits for booting into [Swiss](https://githu
 1. Insert your physical memory card into Slot A or Slot B.
 1. Select the device you want to restore from.
 
-    ![Device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. In GCMM, Press X on a GameCube controller or + on a Wii remote.
 
-    ![Menu](/images/homebrew/gcsaves/gcmm-menu.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-menu.jpg)
 
 1. Select the slot your memory card is in.
 
-    ![Memory](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. Select the save you want to restore. If you have multiple saves to restore, you can press R on the GameCube controller or 1 on the Wii remote to restore all of your saves.
 
-    ![Save](/images/homebrew/gcsaves/gcmm-select-save.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-save.jpg)
 
 1. When restoration is complete, press any button to continue.
 
@@ -73,19 +73,19 @@ If you are looking for save game exploits for booting into [Swiss](https://githu
 1. Insert your physical memory card into slot A or slot B.
 1. Select the device you want to backup to.
 
-    ![Device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. In GCMM, Press Y on a GameCube controller or - on a Wii remote.
 
-    ![Menu](/images/homebrew/gcsaves/gcmm-menu.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-menu.jpg)
 
 1. Select the slot your memory card is in.
 
-    ![Memory](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. Select the save you want to backup. If you have multiple saves to backup, you can press R on the GameCube controller or 1 on the Wii remote to backup all of your saves.
 
-    ![Save](/images/homebrew/gcsaves/gcmm-select-save.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-save.jpg)
 
 1. When backing up is complete, press any button to continue.
 
@@ -109,11 +109,11 @@ If you are looking for save game exploits for booting into [Swiss](https://githu
 1. Insert your memory card into Slot A or Slot B.
 1. Select the device you want to dump to.
 
-    ![Device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. Press L and Y at the same time on GameCube Controller or B and - at the same time on the Wii remote to backup your to a .raw file and select the slot your memory card is in.
 
-    ![Memory](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. When the dump is complete, press any button to continue. It should be saved in a folder on the root of your SD or USB called `MCBACKUP`.
 
@@ -132,12 +132,12 @@ If you are looking for save game exploits for booting into [Swiss](https://githu
 1. Insert your memory card into Slot A or Slot B.
 1. Select the device you want to restore from.
 
-    ![Device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. Press L and X at the same time on GameCube controller or B and + at the same time on the Wii remote.
 1. Select the slot your memory card is in.
 
-    ![Memory](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. It should restore the .raw file to your memory card. When restoration is complete, press any button to continue.
 
@@ -153,13 +153,13 @@ If you are looking for save game exploits for booting into [Swiss](https://githu
 1. Insert both memory cards into the Wii.
 1. From the System menu, navigate into `Wii Options`, `Data Management`, `Save Data`, `Nintendo GameCube`.
 
-    ![sysmenu](/images/homebrew/gcsaves/sysmenu.jpg) <br>
+    ![](/images/homebrew/gcsaves/sysmenu.jpg) <br>
 
-    ![settings](/images/homebrew/gcsaves/settings.jpg) <br>
+    ![](/images/homebrew/gcsaves/settings.jpg) <br>
 
-    ![data management](/images/homebrew/gcsaves/data-management.jpg) <br>
+    ![](/images/homebrew/gcsaves/data-management.jpg) <br>
 
-    ![save data](/images/homebrew/gcsaves/save-data.jpg)
+    ![](/images/homebrew/gcsaves/save-data.jpg)
 
 1. Find the save you want, select it and select `Move or Copy`.
 

--- a/_pages/en_US/hbc-mini.md
+++ b/_pages/en_US/hbc-mini.md
@@ -15,13 +15,13 @@ While it is possible to install BootMii on a Wii mini, you will need to solder a
 
 1. You will see a scam warning screen. Wait 30 seconds for the text "Press 1 to continue" to appear, then press 1.
 
-    ![Scam Screen](/images/hackmii/scam.png)
+    ![](/images/hackmii/scam.png)
 
 1. Press `Continue`, then select `Install The Homebrew Channel`.
 
-    ![Homebrew Channel installation](/images/hackmii/hbc_install.png)
+    ![](/images/hackmii/hbc_install.png)
 
-    ![Homebrew Channel installation OK](/images/hackmii/hbc_install_ok.png)
+    ![](/images/hackmii/hbc_install_ok.png)
 
 1. Press `Continue` when finished.
 1. Once done, select `Exit` to exit the HackMii installer.

--- a/_pages/en_US/hbc.md
+++ b/_pages/en_US/hbc.md
@@ -19,39 +19,39 @@ You can always [install it later](hackmii).
 1. Your console should be powered on and showing the HackMii Installer from the previous part of the guide.
     + You will see a scam warning screen.
 
-    ![Scam Screen](/images/hackmii/scam.png)
+    ![](/images/hackmii/scam.png)
 
 1. Wait 30 seconds for the text "Press 1 to continue" to appear, then press 1.
 1. Select `Continue`.
 
-    ![Results](/images/hackmii/test_results.png)
+    ![](/images/hackmii/test_results.png)
 
 1. Select `Install the Homebrew Channel`.
 
-    ![Homebrew Channel installation](/images/hackmii/hbc_install.png)
+    ![](/images/hackmii/hbc_install.png)
 
 1. Once it is completed, select `Continue`.
 
-    ![Homebrew Channel installation OK](/images/hackmii/hbc_install_ok.png)
+    ![](/images/hackmii/hbc_install_ok.png)
 
 1. Select `Back`, then select `BootMii`.
 
-    ![BootMii](/images/hackmii/bootmii_install.png)
+    ![](/images/hackmii/bootmii_install.png)
 
 1. Select `Install BootMii as IOS`.
 
-    ![BootMii installation](/images/hackmii/bootmii_install1.png)
+    ![](/images/hackmii/bootmii_install1.png)
 
-    ![BootMii SD card prompt](/images/hackmii/bootmii_install2.png)
+    ![](/images/hackmii/bootmii_install2.png)
 
-    ![BootMii SD card preparation](/images/hackmii/bootmii_install3.png)
+    ![](/images/hackmii/bootmii_install3.png)
 
-    ![BootMii installation OK](/images/hackmii/bootmii_install_ok.png)
+    ![](/images/hackmii/bootmii_install_ok.png)
 
 1. Once it is completed, select `Continue`.
 1. If you have the option to `Install BootMii as boot2`, please do so as well.
 
-    ![BootMii boot2 Installation](/images/hackmii/bootmii_install4.png)
+    ![](/images/hackmii/bootmii_install4.png)
 
 1. Select `Exit`.
 1. Your console will have booted into the Homebrew Channel.

--- a/_pages/en_US/homebrew-dolphin.md
+++ b/_pages/en_US/homebrew-dolphin.md
@@ -16,17 +16,17 @@ On Dolphin Emulator version `5.0-4588` or later, the Wii Menu can be easily inst
 
 1. If you have not already done so, install the Wii Menu on Dolphin Emulator by going to `Tools > Perform System Update`.
 
-    ![Perform System Update](/images/homebrew-dolphin/system-update.png)
+    ![](/images/homebrew-dolphin/system-update.png)
 
 1. Download `Open_HBC_(version)_LULZ.wad` from the page linked above.
 1. Open Dolphin Emulator.
 1. Select `Tools > Install WAD` and select the `Open_HBC_(version)_LULZ.wad` file that was downloaded.
 
-    ![Install WAD](/images/homebrew-dolphin/ohbc-file.png)
+    ![](/images/homebrew-dolphin/ohbc-file.png)
 
 1. Select `Tools > Load Wii System Menu`. The channel should now appear.
 
-    ![Homebrew Channel Installed!](/images/homebrew-dolphin/hbc-installed.png)
+    ![](/images/homebrew-dolphin/hbc-installed.png)
 
 ### Post-Installation, installing Homebrew Apps through Open Shop Channel
 
@@ -36,8 +36,8 @@ On Dolphin Emulator version `5.0-4588` or later, the Wii Menu can be easily inst
 1. Open the `SD Sync Folder`. On Windows, this can easily be done by pasting the folder path into the Start Menu, Windows Explorer, or Run.
 1. Extract any homebrew apps to the `WiiSDSync` folder. The end result should look something like this:
 
-    ![Apps Folder](/images/homebrew-dolphin/apps-folder.png)
+    ![](/images/homebrew-dolphin/apps-folder.png)
 
 1. Load the Wii Menu and open the Homebrew Channel. Your newly installed apps should appear!
 
-    ![Homebrew Channel Apps Appearing!](/images/homebrew-dolphin/hbc-apps.png)
+    ![](/images/homebrew-dolphin/hbc-apps.png)

--- a/_pages/en_US/letterbomb.md
+++ b/_pages/en_US/letterbomb.md
@@ -25,19 +25,19 @@ LetterBomb is an exploit for the Wii that is triggered using the Wii Message Boa
     + This letter corresponds to your system menu region, which you will need to know for the corresponding steps.
     + Also, ensure that you are on System Menu version 4.3.
 
-    ![Wii Region](/images/wii/SystemMenuVersion.png)
+    ![](/images/wii/SystemMenuVersion.png)
 
 1. Navigate to `Internet` > `Console Information`.
 1. Take note of your FULL MAC address.
 
-    ![Mac Address](/images/wii/MacAddress.png)
+    ![](/images/wii/MacAddress.png)
 
 1. On your computer, open the browser and go to [the HackMii website](https://please.hackmii.com/).
 1. Input your Wii MAC address and region.
 1. Ensure `Bundle the HackMii Installer for me!` is checked.
 1. Cut either wire.
 
-    ![HackMii Screen](/images/exploits/letterbomb/LetterBomb-PC.png)
+    ![](/images/exploits/letterbomb/LetterBomb-PC.png)
 
 1. Insert your SD card into your computer.
 1. Copy the `private` folder and the `boot.elf` file from the LetterBomb `.zip` to the root of your SD card.
@@ -53,7 +53,7 @@ LetterBomb is an exploit for the Wii that is triggered using the Wii Message Boa
     + If all is correct and there is freezing, keep on trying until it works.
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
 
-![LetterBomb Wii Menu](/images/exploits/letterbomb/LetterBomb-Wii.png)
+![](/images/exploits/letterbomb/LetterBomb-Wii.png)
 
 [Continue to Homebrew Channel and BootMii Installation](hbc)
 {: .notice--info}

--- a/_pages/en_US/nintendont.md
+++ b/_pages/en_US/nintendont.md
@@ -33,7 +33,7 @@ Make sure your storage device is formatted as FAT32. Do not format it to other f
 
 #### User Interface
 
-![Nintendont UI](/images/usb-loaders/nintendont-ui.png)
+![](/images/usb-loaders/nintendont-ui.png)
 
 Nintendont uses a user interface that is mainly controllable and navigable using a gamepad.
 

--- a/_pages/en_US/osc.md
+++ b/_pages/en_US/osc.md
@@ -23,7 +23,7 @@ There are two methods to use the Open Shop Channel: on your Wii through the Home
 
 1. Download the reccomended `.zip` file from the Open Shop Channel website.
 
-    ![Homebrew Browser .ZIP download](/images/osc/zip-download-HBB.png)
+    ![](/images/osc/zip-download-HBB.png)
 
 1. Extract the `apps` folder in the archive to the root of your SD card or USB drive. Optionally, the archive also comes with a guide on how to use the Homebrew Browser.
 1. Insert your SD card or USB drive into your Wii, and go to the Homebrew Channel. The Homebrew Browser should now display.
@@ -40,16 +40,16 @@ There are two methods to use the Open Shop Channel: on your Wii through the Home
 
 1. Download `oscdl-installer.exe` and run the installer. Optionally, you may instead download `oscdl-standalone.exe`, which does not have to be installed and instead runs as a portable executable.
 
-    ![OSCDL executable download](/images/osc/exe-download-OSCDL.png)
+    ![](/images/osc/exe-download-OSCDL.png)
 
 1. If you get a User Account Control pop-up that asks whether or not you would like the program to make changes to your PC, select Yes. Open Shop Channel is a safe application.
 1. Let the installer run, and then launch OSCDL once the process is finished.
 
-    ![OSCDL installer finished](/images/osc/install-finished-OSCDL.png)
+    ![](/images/osc/install-finished-OSCDL.png)
 
 1. Find an application that you would like to get, and press the Download button. Alternatively, you can send the app directly to your Wii (this requires that your computer and Wii be on the same network).
 
-    ![OSCDL app download](/images/osc/app-download-OSCDL.png)
+    ![](/images/osc/app-download-OSCDL.png)
 
 1. A `.zip` file containing your app should download to wherever you specified the directory to be. Extract the `apps` folder in this archive to the root of your SD card or USB drive.
 1. Insert your SD card or USB drive into your Wii, and go to the Homebrew Channel. Your downloaded piece of homebrew should now display.

--- a/_pages/en_US/priiloader.md
+++ b/_pages/en_US/priiloader.md
@@ -40,9 +40,9 @@ There are some important things to take note of:
 1. Launch Priiloader installer from the list of homebrew.
 1. Press the + Button on Wii Remote or the A Button on a GameCube controller.
 
-    ![Install Priiloader](/images/priiloader/installer.png)
+    ![](/images/priiloader/installer.png)
 
-    ![Installing](/images/priiloader/installing.png)
+    ![](/images/priiloader/installing.png)
 
 1. Press A to return to the Homebrew Channel.
 
@@ -50,7 +50,7 @@ There are some important things to take note of:
 
 Priiloader will appear automatically after you install it. Simply exit the Homebrew Channel, and you should see the Priiloader menu:
 
-![Priiloader Menu](/images/priiloader/menu.png)
+![](/images/priiloader/menu.png)
 
 To enter it later on, simply run the "Load Priiloader" homebrew app. There are also other ways to enter Priiloader:
 
@@ -65,7 +65,7 @@ To enter it later on, simply run the "Load Priiloader" homebrew app. There are a
 1. Launch "Load Priiloader" from the list of homebrew.
 1. Scroll down to `System Menu Hacks` and press `A`.
 
-    ![System Menu Hacks](/images/priiloader/menu_hacks.png)
+    ![](/images/priiloader/menu_hacks.png)
 
     If you have put the Priiloader installer on your USB drive, make sure you do not have an SD card inserted at the same time. <br>
     Doing so will cause Priiloader to fail to find the `hacks_hash.ini` file.
@@ -74,7 +74,7 @@ To enter it later on, simply run the "Load Priiloader" homebrew app. There are a
 1. Press `A` on each hack you would like to enable.
     + It is advised to enable "Block Disc Updates", "Block Online Updates", and "Region Free EVERYTHING".
 
-    ![System Menu Hacks List](/images/priiloader/system_menu_hacks.png)
+    ![](/images/priiloader/system_menu_hacks.png)
 
 1. Scroll down to `save settings` and press A.
 1. Press `B` to return to the main menu.
@@ -142,26 +142,26 @@ You will be installing `uneoboot.dol` in step 3.
 1. Launch Load Priiloader from the list of homebrew.
 1. Scroll down to `Load/Install file` and press A.
 
-    ![Load/Install File](/images/priiloader/menu_install_file.png)
+    ![](/images/priiloader/menu_install_file.png)
 
 1. Scroll through the menu until your desired homebrew app is highlighted, and press A to install it.
 
-    ![Installing a Homebrew App](/images/priiloader/installing_file.png)
+    ![](/images/priiloader/installing_file.png)
 
-    ![Installing a Homebrew App OK](/images/priiloader/installing_file_ok.png)
+    ![](/images/priiloader/installing_file_ok.png)
 
 1. Press `B` to return to the main menu.
 1. Scroll down to `Settings` and press A.
 
-    ![Settings](/images/priiloader/menu_settings.png)
+    ![](/images/priiloader/menu_settings.png)
 
 1. Press Right to cycle through the Autoboot options until `Installed file` is selected.
 
-    ![Autoboot: Installed File](/images/priiloader/autoboot_installed_file.png)
+    ![](/images/priiloader/autoboot_installed_file.png)
 
 1. Scroll down to `save settings` and press A.
 
-    ![Saving Settings](/images/priiloader/settings_save.png)
+    ![](/images/priiloader/settings_save.png)
 
 1. Press `B` to return to the main menu.
 1. Scroll back up to `System Menu` and press A.
@@ -174,7 +174,7 @@ Your Wii should now automatically boot to whichever homebrew app you installed.
 1. Launch Load Priiloader from the list of homebrew.
 1. Scroll down to `Settings` and press A.
 
-    ![Settings](/images/priiloader/menu_settings.png)
+    ![](/images/priiloader/menu_settings.png)
 
 1. Press Right to cycle through the Autoboot options until your desired option is selected.
     + Disabled` will autoboot to the Priiloader menu.
@@ -182,11 +182,11 @@ Your Wii should now automatically boot to whichever homebrew app you installed.
     Please don't set Autoboot to `BootMii IOS`. You will get stuck in a loop until you continuously hold the RESET button to enter the Priiloader menu.
     {: .notice--warning}
 
-    ![Autoboot](/images/priiloader/autoboot_disabled.png)
+    ![](/images/priiloader/autoboot_disabled.png)
 
 1. Scroll down to `save settings` and press A.
 
-    ![Saving Settings](/images/priiloader/settings_save.png)
+    ![](/images/priiloader/settings_save.png)
 
 1. Press `B` to return to the main menu.
 1. Scroll back up to `System Menu` and press A.

--- a/_pages/en_US/riiconnect24.md
+++ b/_pages/en_US/riiconnect24.md
@@ -37,45 +37,45 @@ If you are on vWii, you will also need [Priiloader](priiloader) installed with t
     + On macOS/Linux systems, open Terminal and type `bash`, then drag `RiiConnect24Patcher.sh` into the terminal then press enter. It should look like this: `bash <directory>/<directory>/RiiConnect24Patcher.sh`.
 1. Press 1 to choose "`Start`" and confirm your selection by pressing `ENTER`.
 
-    ![RiiConnect24 Patcher Main Screen](/images/riiconnect24/patcher/1.JPG)
+    ![](/images/riiconnect24/patcher/1.JPG)
 
 1. Select the device you're patching for.
 
-    ![Select your device](/images/riiconnect24/patcher/2.JPG)
+    ![](/images/riiconnect24/patcher/2.JPG)
 
 1. For this guide, choose "`Install RiiConnect24 on your Wii`"
 
-    ![Install RiiConnect24](/images/riiconnect24/patcher/3.JPG)
+    ![](/images/riiconnect24/patcher/3.JPG)
 
 1. Choose "`Express (Recommended)`". It will give you everything you need.
 
-    ![Express Settings](/images/riiconnect24/patcher/4.JPG)
+    ![](/images/riiconnect24/patcher/4.JPG)
 
 1. Select your region.
 
-    ![Select your region](/images/riiconnect24/patcher/5.JPG)
+    ![](/images/riiconnect24/patcher/5.JPG)
 
 1. While you're at it, RiiConnect24 Patcher can additionally download some other optional channels that do not use RiiConnect24. `[X]` represents the options that selected. Just press 5 and `ENTER` if you're not interested.
 
-    ![Additional optional channels](/images/riiconnect24/patcher/6.JPG)
+    ![](/images/riiconnect24/patcher/6.JPG)
 
 1. Connect your SD Card or USB Drive to your computer and select "`1`".
 
-    ![Enable copying to SD Card](/images/riiconnect24/patcher/7.JPG)
+    ![](/images/riiconnect24/patcher/7.JPG)
 
 1. If your device was detected successfully, select "`1`". If not, make sure there's a folder called `apps` on your SD Card or USB Drive and try again.
 
-    ![Successfully detected](/images/riiconnect24/patcher/8.JPG)
+    ![](/images/riiconnect24/patcher/8.JPG)
 
 1. The patcher will download apps now - please be patient.
 
-    ![It's patching!](/images/riiconnect24/patcher/9.JPG)
+    ![](/images/riiconnect24/patcher/9.JPG)
 
 1. Once you reach the screen that says `Patching done`, you can exit the patcher. All the files should already be on your SD card.
 
-    ![It's done!](/images/riiconnect24/patcher/10.JPG)
+    ![](/images/riiconnect24/patcher/10.JPG)
 
-    ![Files copied](/images/riiconnect24/patcher/11.PNG)
+    ![](/images/riiconnect24/patcher/11.PNG)
 
 1. If it did not copy everything automatically to your SD Card or USB Device, copy the `WAD` and `apps` folder next to `RiiConnect24Patcher.bat` or `RiiConnect24Patcher.sh` to your SD Card or USB Device.
 

--- a/_pages/en_US/str2hax.md
+++ b/_pages/en_US/str2hax.md
@@ -33,44 +33,44 @@ This exploit requires you to set your DNS in order to connect to a server that c
 1. Power on your console.
 1. Go to `Wii Options`.
 
-    ![Wii Options](/images/riiconnect24/Internet_1.png)
+    ![](/images/riiconnect24/Internet_1.png)
 
 1. Go to `Wii Settings`.
 
-    ![Wii Settings](/images/riiconnect24/Internet_2.png)
+    ![](/images/riiconnect24/Internet_2.png)
 
 1. Navigate to `Page 2` -> `Internet` -> `Connection Settings`.
 
-    ![Internet](/images/riiconnect24/Internet_3.png)
+    ![](/images/riiconnect24/Internet_3.png)
 
-    ![Connection Settings](/images/riiconnect24/Internet_4.png)
+    ![](/images/riiconnect24/Internet_4.png)
 
 1. Click on your network connection slot and navigate to `Change Settings`.
 
-    ![Current Connection](/images/riiconnect24/Internet_5.png)
+    ![](/images/riiconnect24/Internet_5.png)
 
-    ![Change Settings](/images/riiconnect24/Internet_6.png)
+    ![](/images/riiconnect24/Internet_6.png)
 
 1. Set `Auto-Obtain DNS` to `No`, then click `Advanced Settings`.
 
-    ![Auto-Obtain DNS](/images/riiconnect24/Internet_7.png)
+    ![](/images/riiconnect24/Internet_7.png)
 
 1. Set the Primary DNS to `18.188.135.9`.
 
-    ![str2hax DNS](/images/exploits/str2hax/dns.png)
+    ![](/images/exploits/str2hax/dns.png)
 
     If there are 3 fields instead of 2 (like above), go back and make sure you are on the `Auto-Obtain DNS` page.
     {: .notice--warning}
 
 1. Click `Confirm`, then click `Save`.
 
-    ![Save DNS](/images/riiconnect24/Internet_10.png)
+    ![](/images/riiconnect24/Internet_10.png)
 
 1. When prompted, click `OK` to perform the connection test.
 
-    ![Connection Test](/images/riiconnect24/Internet_11.png)
+    ![](/images/riiconnect24/Internet_11.png)
 
-    ![Connection Test Successful](/images/riiconnect24/Internet_12.png)
+    ![](/images/riiconnect24/Internet_12.png)
 
     + If the connection test was successful, select `No` to skip the Wii System Update.
     + If it fails with error code `521xx`, please verify that you have entered the DNS correctly.
@@ -83,12 +83,12 @@ This exploit requires you to set your DNS in order to connect to a server that c
 1. Click on `Next`. 
     + You should be greeted with the following screen:
 
-    ![str2hax EULA page](/images/exploits/str2hax/EULA.png)
+    ![](/images/exploits/str2hax/EULA.png)
 
 1. Give the exploit 1-2 minutes to download (and don't press `I ACCEPT`/`I DO NOT ACCEPT`).
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
 
-    ![HackMii Installer scam screen](/images/hackmii/scam.png)
+    ![](/images/hackmii/scam.png)
 
 [Continue to Homebrew Channel and BootMii Installation](hbc)
 {: .notice--info}

--- a/_pages/en_US/syscheck.md
+++ b/_pages/en_US/syscheck.md
@@ -22,12 +22,12 @@ A SysCheck lists all the IOS and cIOS that are on your Wii, along with some info
 1. Wait for the program to get some information about your Wii.
 1. When "This IOS will be tested (Please select)" is shown on the screen, press A.
 
-    ![Choose IOS](/images/homebrew/syscheck/syscheck_chooseios.png)
+    ![](/images/homebrew/syscheck/syscheck_chooseios.png)
 
 1. Wait for the program to get some information about your IOS.
 1. After it finishes, press the `A` Button if you want to view the log.
 
-    ![Completed](/images/homebrew/syscheck/syscheck_success.png)
+    ![](/images/homebrew/syscheck/syscheck_success.png)
 
 1. If you want to share the SysCheck, you can press the `A` Button, which will upload it to [syscheck.rc24.xyz](http://syscheck.rc24.xyz/) and give you a link. You can also share the `sysCheck.csv` saved to the root of your SD Card or USB Drive. The `IOSsysCheck.log` file (saved to the root as well) contains additional information about your IOS.
 

--- a/_pages/en_US/themes.md
+++ b/_pages/en_US/themes.md
@@ -63,13 +63,13 @@ If you don't want to go through the hassle of using an external program to build
 
 1. Select your storage medium, and you should now see a selection of your themes.
 
-    ![Theme Selection](/images/themes/mym-theme-selection.png)
+    ![](/images/themes/mym-theme-selection.png)
 
 1. Select the theme you would like to install. If it is signed, MyMenuifyMod will indicate it to you, otherwise it will warn you. Be absolutely sure at this point that you have downloaded the correct theme for your system menu version and region.
 1. Install the theme.
 1. Reboot into the Wii Menu, and see if the theme successfully installed. If all goes well, you will have a result similar to the below!
 
-    ![Theme Ready](/images/themes/themed-wii-menu.png)
+    ![](/images/themes/themed-wii-menu.png)
 
 ### WiiFlow Lite Theming
 
@@ -121,24 +121,24 @@ Unfortunately, because of the codebase difference between the original WiiFlow a
 
 1. Download a theme `.zip` file from the website linked above.
 
-    ![Example Theme](/images/themes/homebrew-channel-example-theme.png)
+    ![](/images/themes/homebrew-channel-example-theme.png)
 
 1. Paste the `.zip` into the `apps` folder on your storage device where you load homebrew.
 
-    ![Paste ZIP](/images/themes/homebrew-channel-paste-zip.png)
+    ![](/images/themes/homebrew-channel-paste-zip.png)
 
 1. Extract the contents of the `.zip` into the `apps` folder, and delete the archive.
 
-    ![Extract ZIP](/images/themes/homebrew-channel-extract-theme.png)
+    ![](/images/themes/homebrew-channel-extract-theme.png)
 
 1. Reinsert the storage device into your Wii and enter the Homebrew Channel.
 1. The theme you just installed can be loaded in the same way that you access a standard app.
 
-    ![Load Theme](/images/themes/homebrew-channel-load-theme.png)
+    ![](/images/themes/homebrew-channel-load-theme.png)
 
 1. The theme should now be loaded, enjoy!
 
-    ![Enjoy Theme](/images/themes/homebrew-channel-theme-done.png)
+    ![](/images/themes/homebrew-channel-theme-done.png)
 
 ### App Forwarders
 

--- a/_pages/en_US/transfer-saves.md
+++ b/_pages/en_US/transfer-saves.md
@@ -139,7 +139,7 @@ Unfortunately, you can only select one at a time, so you must repeat the last st
 {% capture dolphin-user-folder %}
 
 `<User Folder>` refers to the folder opened by the `File -> Open User Folder` menu option.
-![Dolphin user folder](/images/dolphin/dolphin-user-folder.png)
+![](/images/dolphin/dolphin-user-folder.png)
 {: .notice--info}
 
 {% endcapture %}
@@ -147,7 +147,7 @@ Unfortunately, you can only select one at a time, so you must repeat the last st
 {% capture dolphin-emu-memcard-manager %}
 
 If Dolphin is set to use a `.raw` memory card, use `Tools > Memory Card Manager` to export your desired saves to `.gci`.
-![Dolphin Emualator Memory Card Manager](/images/homebrew/gcsaves/dolphin-emu-memcard-manager.png)
+![](/images/homebrew/gcsaves/dolphin-emu-memcard-manager.png)
 {: .notice--info}
 
 {% endcapture %}
@@ -176,7 +176,7 @@ All methods here assume you have the [latest Beta or Development version of Dolp
 1. If you exporting a select game's save, right click the game inside the Dolphin window and select `Export Wii Save`.
     + If you are exporting all your Wii saves from Dolphin, select `Tools > Export All Wii Saves`.
 
-    ![Export Wii Save](/images/dolphin/export-wiisave.png)
+    ![](/images/dolphin/export-wiisave.png)
 
 1. In the folder dialog that pops up, select your SD card. (Don't go inside any other folder!)
 1. Safely eject your SD card, then put it into your Wii/Wii U.
@@ -228,7 +228,7 @@ Make sure you have installed [cIOS](cios) before following this!
 1. Open Dolphin Emulator.
 1. In the main menu, select `File > Open User Folder`.
 
-    ![Open User Folder](/images/dolphin/open-user-folder.png)
+    ![](/images/dolphin/open-user-folder.png)
 
 1. In the folder that opens, navigate to `GC > [Save region] > Card A`.
 1. Copy the `.gci` files you would like to put on your Memory Card.
@@ -241,20 +241,20 @@ Make sure you have installed [cIOS](cios) before following this!
 1. Launch the Homebrew Channel, then launch GCMM.
 1. Select the device you have copied the `.gci` files to.
 
-    ![GCMM Select device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. Press `+`/`X` to enter Restore mode.
 
-    ![GCMM Main menu](/images/homebrew/gcsaves/gcmm-menu.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-menu.jpg)
 
 1. Select the slot that has your Memory card.
 
-    ![GCMM Select card slot](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. Select the save you would like to restore.
     + If you would like to restore all the saves in `MCBACKUP`, press `1`/`R`.
 
-    ![GCMM Restore menu](/images/homebrew/gcsaves/gcmm-restore-save.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-restore-save.jpg)
 
 1. When restoration is complete, press any button to continue.
 
@@ -301,15 +301,15 @@ All methods here require a Wii with GameCube ports.
 1. Launch the Homebrew Channel, then launch GCMM.
 1. Select the device you would like to copy the save file to.
 
-    ![GCMM Select device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. Press `B` and `-`/`L` and `Y` to enter Raw backup mode.
 
-    ![GCMM Main menu](/images/homebrew/gcsaves/gcmm-menu.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-menu.jpg)
 
 1. Select the slot that has your memory card.
 
-    ![GCMM Select card slot](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. When the dump is complete, press any key to continue.
 1. Press HOME/START to exit GCMM.
@@ -333,15 +333,15 @@ All methods here require a Wii with GameCube ports.
 1. Launch the Homebrew Channel, then launch GCMM.
 1. Select the device you would like to copy the save file to.
 
-    ![GCMM Select device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. Press `B` and `-`/`L` and `Y` to enter Raw backup mode.
 
-    ![GCMM Main menu](/images/homebrew/gcsaves/gcmm-menu.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-menu.jpg)
 
 1. Select the slot that has your memory card.
 
-    ![GCMM Select card slot](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. When the dump is complete, press any key to continue.
 1. Press HOME/START to exit GCMM.
@@ -371,12 +371,12 @@ All methods here require a Wii with GameCube ports.
 1. Insert both memory cards into your Wii.
 1. Launch the Wii menu and select the Wii Options button at the bottom left.
 
-    ![Wii Options](/images/Wii/wii-options.png)
+    ![](/images/Wii/wii-options.png)
 
 1. Select `Data Management > Save Data > Nintendo GameCube`.
 1. Select the save you would like to copy and select `Copy`.
 
-    ![Copying a GameCube save](/images/homebrew/gcsaves/gc-data-management.png)
+    ![](/images/homebrew/gcsaves/gc-data-management.png)
 
 
 </div>
@@ -429,20 +429,20 @@ All methods here require a Wii with GameCube ports.
 1. Launch the Homebrew Channel, then launch GCMM.
 1. Select the device you have copied the `.gci` files to.
 
-    ![GCMM Select device](/images/homebrew/gcsaves/gcmm-select-device.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-select-device.jpg)
 
 1. Press `+`/`X` to enter Restore mode.
 
-    ![GCMM Main menu](/images/homebrew/gcsaves/gcmm-menu.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-menu.jpg)
 
 1. Select the slot that has your Memory card.
 
-    ![GCMM Select card slot](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-mem-select.jpg)
 
 1. Select the save you would like to restore.
     + If you would like to restore all the saves in `MCBACKUP`, press `1`/`R`.
 
-    ![GCMM Restore menu](/images/homebrew/gcsaves/gcmm-restore-save.jpg)
+    ![](/images/homebrew/gcsaves/gcmm-restore-save.jpg)
 
 1. When restoration is complete, press any button to continue.
 

--- a/_pages/en_US/usb-loaders.md
+++ b/_pages/en_US/usb-loaders.md
@@ -26,14 +26,14 @@ Forwarders to open these loaders on the Wii Menu can be found on the Open Shop C
     + WiiFlow Lite has a plugin system.
     + While the original WiiFlow was last updated in 2014, the WiiFlow Lite fork is still recieving regular updates.
 
-    ![WiiFlow UI](/images/usb-loaders//wiiflow-ui.png)
+    ![](/images/usb-loaders//wiiflow-ui.png)
 
 + USB Loader GX is primarily modeled after the Wii Menu, and supports themes.
     + While SD cards were previously unsupported for loading Wii games on USB Loader GX, recent updates have introduced support into the loader.
     + USB Loader GX has no plugin system.
     + USB Loader GX still recieves regular updates.
 
-    ![USB Loader GX UI](/images/usb-loaders/usbloadergx-ui.png)
+    ![](/images/usb-loaders/usbloadergx-ui.png)
 
 ### Game Directory Structure
 
@@ -84,7 +84,7 @@ When you bring the cursor to the bottom of the screen while in flow view, there 
 + Disc - Loads a game that is in the disc drive.
 + House - Opens the menu below. The menu can also be launched by pressing the home button.
 
-![WiiFlow Menu](/images/usb-loaders/wiiflow-menu.png)
+![](/images/usb-loaders/wiiflow-menu.png)
 
 + Help Guide - Shows all the controls you can use in WiiFlow.
 + Reload Cache - Press this to allow WiiFlow to rescan for games on the USB device or SD card.

--- a/_pages/en_US/wiibackupmanager.md
+++ b/_pages/en_US/wiibackupmanager.md
@@ -38,20 +38,20 @@ You may format it as NTFS, but it won't work with a majority of apps (eg. The Ho
 
 1. Go to the `Drive 1` tab, then select the drive that you're putting the Wii games on.
 
-    ![Select drive](/images/desktop-apps/WBM/select_drive.png)
+    ![](/images/desktop-apps/WBM/select_drive.png)
 
 1. Go to the `Files` tab, then select `Add`.
     + Select `Files` to add multiple games to the program, or select `Folder` to add a whole folder of games.
 
-    ![Select games](/images/desktop-apps/WBM/select_games.png)
+    ![](/images/desktop-apps/WBM/select_games.png)
 
 1. Go to `Select`, then click `Games not on drive 1`.
 
-    ![Highlight games](/images/desktop-apps/WBM/select_games2.png)
+    ![](/images/desktop-apps/WBM/select_games2.png)
 
 1. Select `Transfer`, then select `Drive 1` to transfer the games over. It might take a while for the games to copy over.
 
-    ![Transfer games](/images/desktop-apps/WBM/transfer_todrive.png)
+    ![](/images/desktop-apps/WBM/transfer_todrive.png)
 
 ### Options once complete
 

--- a/_pages/en_US/wiigsc.md
+++ b/_pages/en_US/wiigsc.md
@@ -24,11 +24,11 @@ Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It
 
 1. Install WiiGSC, then right click on it and choose **Run as administrator**. If you do not do this, WiiGSC will throw an error when you open it.
 
-    ![Home menu](/images/desktop-apps/wiigsc/wiigsc-home.png)
+    ![](/images/desktop-apps/wiigsc/wiigsc-home.png)
 
 1. Select the path to the ISO or WBFS file on your USB drive, and select the USB Loader you use. The other options should be fine the way they are.
 
-    ![After selecting the file](/images/desktop-apps/wiigsc/wiigsc-selection.png)
+    ![](/images/desktop-apps/wiigsc/wiigsc-selection.png)
 
 1. Install the generated WAD with your WAD manager.
 

--- a/_pages/en_US/wiimmfi.md
+++ b/_pages/en_US/wiimmfi.md
@@ -27,7 +27,7 @@ A method for Wiimmfi patching which runs on retail disc games automatically via 
 1. Hold the RESET button while turning on your Wii. If you are using a Wii mini, plug in a USB keyboard and hold Escape while turning it ON.
 1. You should see the Priiloader menu.
 
-    ![Menu](/images/Priiloader/mainmenu.jpg)
+    ![](/images/Priiloader/mainmenu.jpg)
 
 1. Go to `System Menu Hacks`.
     If you used a USB drive to install Priiloader, make sure you do not have an SD card inserted at the same time.
@@ -35,7 +35,7 @@ A method for Wiimmfi patching which runs on retail disc games automatically via 
     {: .notice--info}
 1. Make sure the `Wiimmfi patch v4` hack is enabled.
 
-    ![System Menu Hacks](/images/Priiloader/hacks.jpg)
+    ![](/images/Priiloader/hacks.jpg)
 
 1. Scroll to `Save Settings` and save your changes.
 1. Return to the main menu, and press `System Menu` to return to the Wii Menu.
@@ -104,7 +104,7 @@ A method for Wiimmfi patching which runs on retail game discs, but must be manua
 1. Insert your game disc.
 1. Go to `Wii Settings > Internet > Connection Settings` and select whatever connection you are using. Then, `Change Settings > Auto-Obtain DNS NO > Advanced Settings`. Set your primary DNS to `95.217.77.151`, and your secondary DNS to `1.1.1.1`.
 
-    ![DNS Settings for Wiimmfi x str2hax](/images/wiimmfi/dns-str2hax-wiimmfi.png)
+    ![](/images/wiimmfi/dns-str2hax-wiimmfi.png)
 
 1. Let the connection test finish, and do not perform a Wii System Update.
 1. Go back twice to `Internet`, and press `User Agreements`. Then, confirm that you would like to use WC24 and the Wii Shop Channel.

--- a/_pages/en_US/wilbrand.md
+++ b/_pages/en_US/wilbrand.md
@@ -30,19 +30,19 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
 1. Take note of the letter next to the system version, in the top-right corner of the screen.
     + This letter corresponds to your system menu region, which you will need to know for the corresponding steps.
 
-    ![Wii Region](/images/wii/SystemMenuVersion.png)
+    ![](/images/wii/SystemMenuVersion.png)
 
 1. Navigate to `Internet` > `Console Information`.
 1. Take note of your FULL MAC address.
 
-    ![Mac Address](/images/wii/MacAddress.png)
+    ![](/images/wii/MacAddress.png)
 
 1. On your computer, open the browser and go to [wilbrand.donut.eu.org](https://wilbrand.donut.eu.org/).
 1. Input your Wii MAC, version and region.
 1. Ensure `Bundle the HackMii Installer for me!` is checked.
 1. Cut either wire.
 
-    ![Wilbrand Web](/images/exploits/wilbrand/web.png)
+    ![](/images/exploits/wilbrand/web.png)
 
 1. Click on "Download your .zip".
 1. Insert your SD card into your computer.
@@ -56,7 +56,7 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
     + In some cases, you may need to check the messages for tommorow or yesterday for the letter to show up.
     + If you don't see the green letter, check if any errors appear in the SD card section of `Data Management`. If there are errors, there may be an issue with the SD card format or the Wii’s SD card reader.
 
-    ![Wilbrand in its natural habitat](/images/exploits/wilbrand/msgboard.png)
+    ![](/images/exploits/wilbrand/msgboard.png)
 
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
     + If this didn't work for you, try [Wilbrand CLI](#wilbrand-cli) or [try another exploit](get-started) (ie. Letterbomb).
@@ -84,12 +84,12 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
 1. Take note of the letter next to the system version, in the top-right corner of the screen.
     + This letter corresponds to your system menu region, which you will need to know for the corresponding steps.
 
-    ![Wii Region](/images/wii/SystemMenuVersion.png)
+    ![](/images/wii/SystemMenuVersion.png)
 
 1. Navigate to `Internet` > `Console Information`.
 1. Take note of your FULL MAC address.
 
-    ![Mac Address](/images/wii/MacAddress.png)
+    ![](/images/wii/MacAddress.png)
 
 1. Copy all files from the Wilbrand `.zip` to a folder on your computer
 1. Insert your SD card into your computer.
@@ -99,13 +99,13 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
     + Windows: `.\Wilbrand.exe AA-BB-CC-DD-EE-FF MM/DD/YYYY VERSION X:`
         + `X:` is the drive letter of your SD card.
 
-        ![running Wilbrand on Windows](/images/exploits/wilbrand/windows.png)
+        ![](/images/exploits/wilbrand/windows.png)
 
     + Linux/macOS: `./Wilbrand AA-BB-CC-DD-EE-FF MM/DD/YYYY VERSION /media/mount_dir`
         + If you have not opened your terminal directly in the folder Wilbrand was extracted to, use `cd` to enter it first, eg. `cd ~/Desktop/Wilbrand`
         + `/media/mount_dir` is the folder your SD card is mounted in. This may vary depending on your Linux distro.
 
-        ![running Wilbrand on Linux](/images/exploits/wilbrand/linux.png)
+        ![](/images/exploits/wilbrand/linux.png)
 
 1. Copy all files from the hackmii_installer_v1.2 `.zip` to a folder on your computer.
 1. Copy `boot.elf` from the hackmii_installer_v1.2 `.zip` to the root of your SD card.
@@ -118,7 +118,7 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
     + In some cases, you may need to check the messages for tommorow or yesterday for the letter to show up.
     + If you don't see the green letter, check if any errors appear in the SD card section of `Data Management`. If there are errors, there may be an issue with the SD card format or the Wii’s SD card reader.
 
-    ![Wilbrand in its natural habitat](/images/exploits/wilbrand/msgboard.png)
+    ![](/images/exploits/wilbrand/msgboard.png)
 
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
 

--- a/_pages/en_US/yawmme.md
+++ b/_pages/en_US/yawmme.md
@@ -22,23 +22,23 @@ This tutorial will show you how to install WADs.
 
 1. Select the source device that has the WAD file(s) you would like to install.
 
-    ![Selecting source device](/images/homebrew/yawmME/source_device.png)
+    ![](/images/homebrew/yawmME/source_device.png)
 
 1. Navigate to the folder that has the WAD files.
     + If you have a folder named `wad`, it will be opened automatically.
 
-    ![Selecting WAD file](/images/homebrew/yawmME/file_selection.png)
+    ![](/images/homebrew/yawmME/file_selection.png)
 
 1. Navigate to the WAD file you would like to install and press `A`.
     + If you would like to install multiple WAD files at once, press `+` on each of them, then press `A`.
 
-    ![WAD options](/images/homebrew/yawmME/install_wad.png)
+    ![](/images/homebrew/yawmME/install_wad.png)
 
 1. Press A again to install the WAD(s).
 
-    ![Installing WAD](/images/homebrew/yawmME/installing_wad.png)
+    ![](/images/homebrew/yawmME/installing_wad.png)
 
-    ![Installing WAD OK](/images/homebrew/yawmME/installing_wad_ok.png)
+    ![](/images/homebrew/yawmME/installing_wad_ok.png)
 
 [Click here to go back to the site index.](site-navigation)
 {: .notice--info}


### PR DESCRIPTION
**Description**

This may break users that are possibly on Internet Explorer or something, but I don't know.

It *is* a translation burden, on the other hand, and largely unnecessary.

Regex used: `!\[.*\]`
