### PR TITLE
Redirect to actual WiiLink install guide

### DIFF
--- a/_pages/en_US/wiiconnect24.md
+++ b/_pages/en_US/wiiconnect24.md
@@ -34,7 +34,7 @@ Both services listed below are compatible with one another and can be loaded on 
 A newer WC24/Japanese channel revival service that started in 2020, but is rapidly regaining functionality in many different channels.
     
 Service support status can be found [here](https://www.wiilink24.com/status).<br>
-Their guide can be found [here](https://www.wiilink24.com/guide/1welcome/).
+Their guide can be found [here](https://www.wiilink24.com/guide/2installation/).
 
 #### RiiConnect24
 The longest lasting WC24 revival service, currently only with support for the worldwide WC24 channels as well as mail services.


### PR DESCRIPTION


<!--What does this pull request do? Why is it needed?-->
Redirect straight to the guide page, since the Welcome page redirects to a 404 link, you have to go to the sidebar on the Welcome page to get to the proper install guide page, which is inconveinent.
