### PR TITLE
Update wii-loaders.md

### DIFF
--- a/_pages/en_US/wii-loaders.md
+++ b/_pages/en_US/wii-loaders.md
@@ -12,7 +12,7 @@ In order for Wii loader to function properly, you must have the latest cIOS inst
 To play games, you are advised to use a large SD card or an external hard drive, flash drives are not recommended and very sporadic in functionality. See [storage FAQ](faq).
 {: .notice--info}
 
-The official Wii menu forwarder installer for Wiiflow Lite can be found on the [Open Shop Channel](https://oscwii.org/library/app/wiiflow_channel_installer). Run the app in the Homebrew Channel to install the forwarder. The USB Loader GX official forwarder can be found on the [SourceForge](https://sourceforge.net/projects/usbloadergx/files/Releases/Forwarders/USB%20Loader%20GX-UNEO_Forwarder_5_1_AHBPROT.wad/download) page. You can install it with [YAWM ModMii Edition](yawmme).
+The official Wii menu forwarder installer for Wiiflow Lite can be found on the [Open Shop Channel](https://oscwii.org/library/app/wiiflow_channel_installer). Run the app in the Homebrew Channel to install the forwarder. The USB Loader GX official forwarder can be found on the [GitHub](https://github.com/wiidev/usbloadergx/raw/updates/USBLoaderGX_forwarder%5BUNEO%5D_Wii.wad) page. You can install it with [YAWM ModMii Edition](yawmme).
 {: .notice--info}
 
 ### Differences between WiiFlow Lite and USB Loader GX


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->
https://github.com/wiidev/usbloadergx is the version on the OSC, who is still maintained, as such, probably a good idea to use it's Forwarder instead of using the Forwarder from the old SourceForge version