### PR TITLE
Add a redirect macro and initial stub pages

### DIFF
--- a/_includes/redirect.html
+++ b/_includes/redirect.html
@@ -1,0 +1,2 @@
+<meta http-equiv="refresh" content="0; URL={{ include.redirect_to }}">
+<link rel="canonical" href="{{ include.redirect_to }}">

--- a/_pages/en_US/410.md
+++ b/_pages/en_US/410.md
@@ -1,0 +1,12 @@
+---
+title: "Page no longer exists" #
+sitemap: false
+---
+
+The page you are trying to view used to exist, but it has since been removed. Maybe the instructions you are following are outdated? (If you got here from a link on this guide, [let us know](https://github.com/hacks-guide/Guide_Wii/issues))
+
+[Click here to go back to the site index.](site-navigation)
+{: .notice--info}
+
+![](https://http.cat/410)
+{: .notice--info}

--- a/_pages/en_US/nintendont.md
+++ b/_pages/en_US/nintendont.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="410.html" %}

--- a/_pages/en_US/riiconnect24.md
+++ b/_pages/en_US/riiconnect24.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="https://www.wiilink24.com/guide/install/" %}

--- a/_pages/en_US/riitag.md
+++ b/_pages/en_US/riitag.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="410.html" %}

--- a/_pages/en_US/riivolution.md
+++ b/_pages/en_US/riivolution.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="410.html" %}

--- a/_pages/en_US/usbloadergx.md
+++ b/_pages/en_US/usbloadergx.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="wii-loaders.html" %}

--- a/_pages/en_US/wiibackupmanager.md
+++ b/_pages/en_US/wiibackupmanager.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="wii-backups.html" %}

--- a/_pages/en_US/wiiflow.md
+++ b/_pages/en_US/wiiflow.md
@@ -1,0 +1,5 @@
+---
+title: Redirecting...
+---
+
+{% include redirect.html redirect_to="wii-loaders.html" %}


### PR DESCRIPTION
**Description**

As RiiConnect24 is no longer maintaining wii.guide, it is now redirecting to wii.hacks.guide.

A lot of once-popular pages on wii.guide is causing 404s as a result of our guide refactoring many pages that used to be there. Let's try to fix it.

The include macro should make it very simple to add redirects.
