### PR TITLE
Customize main.scss to fix get started table

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -24,8 +24,9 @@
   }
 
   .console-img {
-    margin-top: auto;
-    margin-bottom: auto;
+    display: flex;
+    justify-content: center;
+    align-items: center;
  }
   
   .r1 { grid-row: 1; }


### PR DESCRIPTION
Console identification table no longer cuts off outline by the height of the image in that specific column - now it is appended to the height of the largest image.
