### PR TITLE
Poor man's attempt at trying not to shove info into user's faces

### DIFF
--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -4,13 +4,13 @@ title: "BlueBomb"
 
 {% include toc title="Table of Contents" %}
 
+BlueBomb is an exploit that takes advantage of a flaw in the Wii and Wii mini's Bluetooth libraries. Although it is the only exploit that works for the Wii mini, BlueBomb can run on the original Wii as well. This exploit also enables recovery from certain bricks, such as Korean Kii/Error 003.
+
 It is **strongly** advised against using **any** video guide for hacking your Wii mini console, as there is an extremely large chance of **bricking** it.
 {: .notice--warning}
 
 If you need help with anything regarding this tutorial, please join [the Wii mini Hacking Discord server](https://discord.gg/6ryxnkS) (recommended)
 {: .notice--info}
-
-BlueBomb is an exploit that takes advantage of a flaw in the Wii and Wii mini's Bluetooth libraries. Although it is the only exploit that works for the Wii mini, BlueBomb can run on the original Wii as well. This exploit also enables recovery from certain bricks, such as Korean Kii/Error 003.
 
 If you are using the original revision of the Wii, you should probably find [another exploit to use](get-started) as there are much easier ways to get to the HackMii installer. Exceptions however, exist in circumstances like brick recovery.
 {: .notice--info}

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -4,7 +4,7 @@ title: "BlueBomb"
 
 {% include toc title="Table of Contents" %}
 
-BlueBomb is an exploit that takes advantage of a flaw in the Wii and Wii mini's Bluetooth libraries. Although it is the only exploit that works for the Wii mini, BlueBomb can run on the original Wii as well. This exploit also enables recovery from certain bricks, such as Korean Kii/Error 003.
+BlueBomb is an exploit that takes advantage of a flaw in the Wii and Wii mini's Bluetooth libraries. Although it is the only exploit that works for the Wii mini, BlueBomb can run on the original Wii as well. This exploit also enables recovery from certain bricks, such as banner bricks and (some) theme bricks.
 
 It is **strongly** advised against using **any** video guide for hacking your Wii mini console, as there is an extremely large chance of **bricking** it.
 {: .notice--warning}

--- a/_pages/en_US/cios.md
+++ b/_pages/en_US/cios.md
@@ -4,7 +4,13 @@ title: "cIOS"
 
 {% include toc title="Table of Contents" %}
 
+{% capture technical_info %}
+<summary><em>Technical Details (optional)</em></summary>
 While [cIOS](https://wiibrew.org/wiki/Custom_IOS) has largely been supplanted by AHBPROT, which gives complete hardware access, it still has useful applications. For example, this enables the functionality of USB loaders like USB Loader GX and WiiFlow, alongside other pieces of homebrew like SaveGame Manager GX. You can skip this process if you want, but generally it extends your Wii with little to no downsides.
+
+{% endcapture %}
+<details>{{ technical_info | markdownify }}</details>
+{: .notice--info}
 
 If you have a Wii mini, use [this](cios-mini) guide for cIOS instead. Attempting to install other cIOS on a Wii mini will not work.
 {: .notice--warning}

--- a/_pages/en_US/cios.md
+++ b/_pages/en_US/cios.md
@@ -28,11 +28,6 @@ Ensure that if you are using an SD card, the lock switch is in the unlocked posi
 
 #### Section I - Downloading
 
-If your Wii has an Internet connection, you may skip this section.<br>
-However, If you encounter any errors like `net_init failed`, `net_gethostbyname failed:`, or any other issues during the downloading stage
-this will allow the Wii to skip the downloading step.
-{: .notice--warning}
-
 If you are not on Windows, you may download & run [this script](/assets/files/d2x_offline_ios.sh), and it will download the WAD files for you.
 {: .notice--info}
 

--- a/_pages/en_US/get-started.md
+++ b/_pages/en_US/get-started.md
@@ -17,7 +17,7 @@ It is recommended to at least have an SD card on hand after the initial hack pro
 
 ### Select your exploit
 
-Select the exploit that corresponds to your console and situation the best. If the recommended option does not work for you, or if you are curious about other exploits, check out [Legacy Exploits](legacy-exploits).
+Select the exploit that corresponds to your console and situation the best.
 
 | Console Revision  | Recommended Exploit |
 | ----------------- | ------------------- |
@@ -25,3 +25,9 @@ Select the exploit that corresponds to your console and situation the best. If t
 | Wii mini | Proceed to [Bluebomb](bluebomb) |
 | Wii U (vWii)  | If you have not modded your Wii U yet:<br> Proceed to [Introduction (wiiu.hacks.guide)](https://wiiu.hacks.guide/#/)<br> If your Wii U is already modded:<br> Proceed to [vWii Modding (wiiu.hacks.guide)](https://wiiu.hacks.guide/#/vwii/sd-preparation) |
 | Dolphin Emulator | Proceed to [Homebrew Channel on Dolphin](homebrew-dolphin) |
+
+### Alternate methods
+
+If possible, you should follow the method given above.
+
+If the recommended option does not work for you, or if you are curious about other exploits, check out [Legacy Exploits](legacy-exploits).

--- a/_pages/en_US/get-started.md
+++ b/_pages/en_US/get-started.md
@@ -4,13 +4,12 @@ title: "Get Started"
 
 {% include toc title="Table of Contents" %}
 
-It is recommended to at least have an SD card on hand after the initial hack process, as this will enable you to make a NAND backup using BootMii and install many types of homebrew.
-{: .notice--info}
+These steps will help you softmod your Wii, from stock to BootMii. Before starting this guide, please ensure that your console is on the latest version of the Wii firmware (4.3). If your Wii is already softmodded but is on an older version, follow [this](update) guide to upgrade your setup.
 
 All of the exploits listed here are different methods of achieving the same end-result (getting to the HackMii installer).
-{: .notice--info}
 
-These steps will help you softmod your Wii, from stock to BootMii. Before starting this guide, please ensure that your console is on the latest version of the Wii firmware (4.3). If your Wii is already softmodded but is on an older version, follow [this](update) guide to upgrade your setup.
+It is recommended to at least have an SD card on hand after the initial hack process, as this will enable you to make a NAND backup using BootMii and install many types of homebrew.
+{: .notice--info}
 
 ### Identify your console revision:
 

--- a/_pages/en_US/hbc.md
+++ b/_pages/en_US/hbc.md
@@ -4,10 +4,15 @@ title: "Homebrew Channel and BootMii Installation"
 
 {% include toc title="Table of Contents" %}
 
+{% capture technical_info %}
+<summary><em>Technical Details (optional)</em></summary>
 The Homebrew Channel is where you will go to launch homebrew applications.
 BootMii is a piece of software that can backup and restore your Wii's NAND storage, and if installed in boot2, provide brick protection.
 
 BootMii can be installed in two ways: directly to a part of the Wii bootloader called boot2, and via an IOS. BootMii under boot2 is preferred as it provides extended brick protection, but Wiis with a vulnerable boot1 that allows this installation are considerably rarer, having been manufactured before 2009. In most cases, installing BootMii as IOS should be fine, as long as you also install [Priiloader](priiloader).
+
+{% endcapture %}
+<details>{{ technical_info | markdownify }}</details>
 {: .notice--info}
 
 If you do not have an SD card, you cannot install nor use BootMii, regardless of whether you install it as IOS or boot2.

--- a/_pages/en_US/letterbomb.md
+++ b/_pages/en_US/letterbomb.md
@@ -4,13 +4,13 @@ title: "LetterBomb"
 
 {% include toc title="Table of Contents" %}
 
+LetterBomb is an exploit for the Wii that is triggered using the Wii Message Board.
+
 For instructions on how to format your SD card correctly, please see [this guide](https://wiki.hacks.guide/wiki/Formatting_an_SD_card). It is highly recommended to check it due to problems with formatting as FAT32.
 {: .notice--info}
 
 Do NOT use any of the MAC address examples shown in this guide, as they will simply cause an error on the HackMii website. Use your own!
 {: .notice--warning}
-
-LetterBomb is an exploit for the Wii that is triggered using the Wii Message Board.
 
 ### Requirements
 * An SD card formatted as FAT32

--- a/_pages/en_US/osc.md
+++ b/_pages/en_US/osc.md
@@ -7,7 +7,7 @@ title: "Open Shop Channel"
 For support (in English) with the Open Shop Channel, join [Open Shop Channel on Discord](https://discord.gg/osc).
 {: .notice--primary}
 
-The [Open Shop Channel](https://oscwii.org/) is a homebrew app repository created by dhtdht020, and is currently the preferred way to download homebrew. Not only is it more convenient due to having the most commonly used homebrew in one place, but it is also safer as apps are manually added to the repository. You can see where an app is being obtained from by checking its [manifest](https://github.com/OpenShopChannel/Apps/tree/master/contents).
+The [Open Shop Channel](https://oscwii.org/) is a homebrew app repository created by dhtdht020, and is currently the preferred way to download homebrew.
 
 There are two methods to use the Open Shop Channel: on your Wii through Homebrew Browser, or outside of your Wii through OSCDL.
 

--- a/_pages/en_US/str2hax.md
+++ b/_pages/en_US/str2hax.md
@@ -9,22 +9,14 @@ Note that if your ISP or networking environment prevents using custom DNS server
 
 str2hax is an exploit for the Wii that is triggered by loading the Wii's End User License Agreement. It requires nothing but an Internet connection that lets you change the DNS on your Wii.
 
+If you have installed a mod like CTGP Revolution or Project+, str2hax may load that instead. If it does, restart your Wii and try again without your SD card inserted.
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii with an Internet connection
 
 ### Instructions
-
-#### Common issues
-
-If you get the normal User Agreements, your ISP blocks the use of custom DNS. Please [use another exploit](get-started).
-{: .notice--warning}
-
-If the HackMii Installer doesn't load after more than 2 minutes, or you receive an error like `Hanging.` or `ERROR! if_config (ret = ...)`, please restart your Wii and try again.
-{: .notice--warning}
-
-If you have installed a mod like CTGP Revolution or Project+, str2hax may load that instead. If it does, restart your Wii and try again without your SD card inserted.
-{: .notice--warning}
 
 #### Section I - Connecting
 
@@ -85,10 +77,14 @@ This exploit requires you to set your DNS in order to connect to a server that c
 
     ![](/images/exploits/str2hax/EULA.png)
 
+    + If you get the normal User Agreements, your ISP blocks the use of custom DNS. Try another connection, or [use another exploit](get-started).
+
 1. Give the exploit 1-2 minutes to download (and don't press `I ACCEPT`/`I DO NOT ACCEPT`).
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
 
     ![](/images/hackmii/scam.png)
+
+    + If the HackMii Installer doesn't load after more than 2 minutes, or you receive an error like `Hanging.` or `ERROR! if_config (ret = ...)`, please restart your Wii and try again.
 
 [Continue to Homebrew Channel and BootMii Installation](hbc)
 {: .notice--info}

--- a/_pages/en_US/wilbrand.md
+++ b/_pages/en_US/wilbrand.md
@@ -4,10 +4,7 @@ title: "Wilbrand"
 
 {% include toc title="Table of Contents" %}
 
-Wilbrand, like LetterBomb, is an exploit for the Wii that is triggered using the Wii Message Board.
-
-Unlike LetterBomb, Wilbrand supports Wii menu versions down to 3.0.
-{: .notice--info}
+Wilbrand is an exploit for the Wii that is triggered using the Wii Message Board. It is compatible with Wii menu versions 3.0 through 4.3 in all regions.
 
 There are two methods listed on this page used to create the proper Wilbrand exploit.
 Wilbrand Web is recommended for its ease of use.

--- a/_pages/en_US/wilbrand.md
+++ b/_pages/en_US/wilbrand.md
@@ -56,7 +56,7 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
     ![](/images/exploits/wilbrand/msgboard.png)
 
 1. If the exploit was successful, your device will have loaded the HackMii Installer.
-    + If this didn't work for you, try [Wilbrand CLI](#wilbrand-cli) or [try another exploit](get-started) (ie. Letterbomb).
+    + If this didn't work for you, try [Wilbrand CLI](#wilbrand-cli) or [try another exploit](get-started).
 
 [Continue to Homebrew Channel and BootMii Installation](hbc)
 {: .notice--info}


### PR DESCRIPTION
**Description**

See title.

Breaking changes:
- Make user download IOS from NUSD regardless of whether the console's Internet is working
  - See commit message

Detailed changes:
- Moved some large boilerplate info text into a dropdown in some cases
- Try to inline some notices instead of posting at top
- Move around intro notices so that non-notice text isn't squashed in the middle
- Remove some unnecessary text
- Don't hint at LetterBomb when Wilbrand isn't working


We could use some more "hide in infobox" for a lot of these introductory texts; I didn't go through all the pages (maybe I will at some point.)