### PR TITLE
Add disclaimer that the Wii's IOSses should not be confused with Apple's iOS

### DIFF
--- a/_pages/en_US/cios.md
+++ b/_pages/en_US/cios.md
@@ -21,7 +21,7 @@ If you have a Wii mini, use [this](cios-mini) guide for cIOS instead. Attempting
 * An SD card or USB drive
 * [d2x cIOS Installer](/assets/files/d2x-cios-installer.zip)
 
-It is helpful to note that IOS on the Wii is not affiliated with iOS on Apple devices, and does not bare much technical similarities internally. Do not get the Wii IOSs and Apple's iOS mixed up, as it may cause confusion.
+It is helpful to note that IOS on the Wii is not related to iOS on Apple devices, and does not bear much technical similarities internally. Do not get the Wii IOSs and Apple's iOS mixed up.
 {: .notice--info}
 
 

--- a/_pages/en_US/cios.md
+++ b/_pages/en_US/cios.md
@@ -21,6 +21,10 @@ If you have a Wii mini, use [this](cios-mini) guide for cIOS instead. Attempting
 * An SD card or USB drive
 * [d2x cIOS Installer](/assets/files/d2x-cios-installer.zip)
 
+It is helpful to note that IOS on the Wii is not affiliated with iOS on Apple devices, and does not bare much technical similarities internally. Do not get the Wii IOSs and Apple's iOS mixed up, as it may cause confusion.
+{: .notice--info}
+
+
 Ensure that if you are using an SD card, the lock switch is in the unlocked position, otherwise you will not be able to select the correct options in the installer.
 {: .notice--warning}
 


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->
Most people automatically associate the acronym "IOS" with Apple iOS. IOSses on the Wii should not be confused with Apple iOS, as it may confuse some people not too familiar with the internals of the Wii/GC.
