### PR TITLE
Fix FlashHax link in legacy-exploits.md

### DIFF
--- a/_pages/en_US/legacy-exploits.md
+++ b/_pages/en_US/legacy-exploits.md
@@ -98,7 +98,7 @@ Note for vWii: if one of these exploits is planned to be used, it is recommended
 + Executes the chainloader via a web page in the Internet Channel.
 + Works regardless of system menu version, only requirement is patience as exploit is extremely unreliable. vWii was not capable of installing internet channel via the Wii Shop Channel.
 + Superceded by str2hax, or by using an SD card for Letterbomb.
-+ [Wiibrew Page](https://wiibrew.org/wiki/Flashhax) or [Exploit Page](flashhax)
++ [Wiibrew Page](https://wiibrew.org/wiki/FlashHax) or [Exploit Page](flashhax)
 
 #### Wuphax (vWii only)
 


### PR DESCRIPTION
**Description**

The original wiibrew flashhax link doesn't work (the wiibrew wiki is case-sensitive).
