### PR TITLE
Add a warning about the hard limit number of "wii game shortcuts"

### DIFF
--- a/_pages/ca_ES/wiigsc.md
+++ b/_pages/ca_ES/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii

--- a/_pages/de_DE/wiigsc.md
+++ b/_pages/de_DE/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Anforderungen
 
 * Eine Wii

--- a/_pages/en_US/wiigsc.md
+++ b/_pages/en_US/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii

--- a/_pages/es_419/wiigsc.md
+++ b/_pages/es_419/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii

--- a/_pages/fr_FR/wiigsc.md
+++ b/_pages/fr_FR/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Prérequis
 
 * Une Wii

--- a/_pages/hu_HU/wiigsc.md
+++ b/_pages/hu_HU/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Követelmények
 
 * Egy Wii

--- a/_pages/ja_JP/wiigsc.md
+++ b/_pages/ja_JP/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### 必要なもの
 
 * A Wii

--- a/_pages/no_NO/wiigsc.md
+++ b/_pages/no_NO/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii

--- a/_pages/pl_PL/wiigsc.md
+++ b/_pages/pl_PL/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii

--- a/_pages/pt_PT/wiigsc.md
+++ b/_pages/pt_PT/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Requirements
 
 * A Wii

--- a/_pages/ro_RO/wiigsc.md
+++ b/_pages/ro_RO/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Instrumente necesare
 
 * Un Wii

--- a/_pages/ru_RU/wiigsc.md
+++ b/_pages/ru_RU/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Требования
 
 * A Wii

--- a/_pages/tr_TR/wiigsc.md
+++ b/_pages/tr_TR/wiigsc.md
@@ -12,6 +12,9 @@ In the case of a brick, [installing Priiloader is a must](/priiloader). Also, in
 Do NOT make a shortcut for the games "Mario Party 9" or "A Boy and His Blob". It will brick your Wii.
 {: .notice--warning}
 
+The Wii Menu is hard limited to a maximum of 48 channels and 6 of them are taken by channels you cannot remove, like the Wii shop. If you need more channels, the standard solution is to use one of the [Wii Loaders](wii-loaders).
+{: .notice--warning}
+
 ### Gereksinimler
 
 * A Wii


### PR DESCRIPTION
**Description**

I was looking to create shortcuts for all of the backup Wii games on my USB drive. The idea was to avoid using USB Loader GX and disrupt the user experience for the person using the Wii.

I stumbled on the "Creating Wii Game Shortcuts" guide - aka https://wii.hacks.guide/wiigsc. I then was able to create all my wad files, I installed them, it worked.... only to realize I could not see all the games.

I searched on the tubes only to understand that, the Wii is limited to 48 channels and this is a hard limit. In fact, the community probably created these loaders like USB Loader GX to circumvent this kind of limitation I wasn't aware of.

So, if the documentation had a clear warning at the begining, stipulating I would be limited to 36 or so channels for my games, I would have NOT created and installed all those wad files.