### PR TITLE
Update wii-loaders.md

### DIFF
--- a/_pages/en_US/wii-loaders.md
+++ b/_pages/en_US/wii-loaders.md
@@ -33,7 +33,7 @@ The official Wii Menu forwarder installer for WiiFlow Lite can be found on the [
 
 ### Game Directory Structure
 
-Below is a single WBFS example, and a split WBFS example. A WBFS needs to be split if your storage device is formatted as FAT32 and is over 4 GB. Software such as [Wii Backup Manager](wii-backups#using-wii-backup-manager) or [Wii Backup Fusion](wii-backups#using-wii-backup-fusion) can do this for you, and will automatically set up the game directory structure correctly.
+Below is a single WBFS example, and a split WBFS example. A WBFS needs to be split if it is over 4 GB and your storage device is formatted as FAT32. Software such as [Wii Backup Manager](wii-backups#using-wii-backup-manager) or [Wii Backup Fusion](wii-backups#using-wii-backup-fusion) can do this for you, and will automatically set up the game directory structure correctly.
 
 ```
 💾SD card or USB:


### PR DESCRIPTION
Adjust confusing wording on when files need to be split

**Description**

Guide currently reads as "if you have a storage device that is over 4GB, you need to split WBFS files" due to ambiguous wording -- simple, small re-wording commit here
