### PR TITLE
better way of running the bluebomb helper script.

### DIFF
--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -68,7 +68,7 @@ Make sure that the console is close to the computer running the exploit, ideally
 1. Run the following command:
 
    ```bash
-   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | sh
+   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | bash
    ```
 
 1. The helper will then download the required files, and ask for information about your console.

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -68,7 +68,7 @@ Make sure that the console is close to the computer running the exploit, ideally
 1. Run the following command:
 
    ```bash
-	wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | sh
+   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | sh
    ```
 
 1. The helper will then download the required files, and ask for information about your console.

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -65,13 +65,11 @@ Make sure that the console is close to the computer running the exploit, ideally
 1. Power off your console.
 1. Start your Linux distro, and ensure you are connected to the internet.
 1. Open the Terminal
-1. Run the following commands:
+1. Run the following command:
 
-    ```bash
-    wget https://wii.hacks.guide/assets/files/bluebomb-helper.sh
-    chmod +x bluebomb-helper.sh
-    ./bluebomb-helper.sh
-    ```
+   ```bash
+	wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | sh
+   ```
 
 1. The helper will then download the required files, and ask for information about your console.
     + If you have selected a Wii mini you will be asked to provide your region. This can be determined by the last letter of the Wii Menu version (`U` for **USA** and `E` for **PAL** models).

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -68,7 +68,7 @@ Make sure that the console is close to the computer running the exploit, ideally
 1. Run the following command:
 
    ```bash
-   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | bash
+   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | $SHELL
    ```
 
 1. The helper will then download the required files, and ask for information about your console.

--- a/_pages/en_US/bluebomb.md
+++ b/_pages/en_US/bluebomb.md
@@ -68,7 +68,7 @@ Make sure that the console is close to the computer running the exploit, ideally
 1. Run the following command:
 
    ```bash
-   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | $SHELL
+   wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | bash
    ```
 
 1. The helper will then download the required files, and ask for information about your console.


### PR DESCRIPTION
**Description**

this pr basically fits the entire downloading and running process into one command, so the users don't have to run 3 commands.

the old commands are:
```bash
wget https://wii.hacks.guide/assets/files/bluebomb-helper.sh
chmod +x bluebomb-helper.sh
./bluebomb-helper.sh
```
and the new command is:
```bash
wget -qO- https://wii.hacks.guide/assets/files/bluebomb-helper.sh | sh
```

if i did anything wrong, please notify me because this is my first time contributing here.