### PR TITLE
Make link to Wii Backup Fusion the Releases page

### DIFF
--- a/docs/wii-backups.md
+++ b/docs/wii-backups.md
@@ -105,7 +105,7 @@ If your disc was dumped to a FAT32 device, you should have gotten at least two f
 * A PC running MacOS or Linux
 * A USB drive or SD card
 * A dumped ISO from a Wii game disc
-* [Wii Backup Fusion](https://github.com/larsenv/Wii-Backup-Fusion)
+* [Wii Backup Fusion](https://github.com/larsenv/Wii-Backup-Fusion/releases)
 * [Wiimm's ISO Tools](https://wit.wiimm.de/download.html)
 
 ### Instructions


### PR DESCRIPTION
Pretty simple change, saw some folks getting confused on how/where to download Wii Backup Fusion so this adjusts the hyperlink to point to the Releases tab