### PR TITLE
Update guide with clearer info on SD card formatting requirement

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,9 +54,9 @@ For the [BlueBomb](bluebomb), [str2hax](str2hax), or [FlashHax](flashhax) exploi
 
 ::: info
 
-FAT32 is the recommended file system for SD cards, see [this guide](https://wiki.hacks.guide/wiki/Formatting_an_SD_card) on formatting instructions.
+The Wii can read SD cards of any capacity (even those larger than 32GB), but the card must be formatted to FAT32 (**not** exFAT or NTFS). See [this guide](https://wiki.hacks.guide/wiki/Formatting_an_SD_card) on formatting instructions.
 
-For USB devices, FAT32 is also recommended, although users should be aware of FAT32 limitations which only allow volumes up to 2TB in size. WBFS was a previously used file system for Wii game backups (not to be confused with WBFS files) - today, it is outdated and should not be used.
+For USB devices, FAT32 is also recommended, although users should be aware of FAT32 limitations which only allow volumes up to 2TB in size and files up to 4GB in size. WBFS was a previously used file system for Wii game backups (not to be confused with WBFS files) - today, it is outdated and should not be used.
 
 :::
 
@@ -64,9 +64,7 @@ For USB devices, FAT32 is also recommended, although users should be aware of FA
 
 For stock Wii Menu versions lower than 4.0, a limitation in the Wii system software prevents SD cards bigger than 2GB from being used.
 
-For stock Wii Menu versions 4.0 or higher, this limitation is removed and SD cards of various sizes can be used.
-
-Your highest chance of getting a working SD card on any Wii is at sizes 32GB or lower, but success has been reported various times on cards ranging up to 256GB.
+For stock Wii Menu versions 4.0 or higher, this limitation is removed and SD cards of any size can be used.
 
 :::
 

--- a/docs/key-information.md
+++ b/docs/key-information.md
@@ -52,7 +52,7 @@ Be especially cautious with IOS to avoid bricking, since they are specifically d
 
 ## Storage Compatibility
 
-For SD cards, you will want a minimum of 128MB to run an exploit. On average, however, you will want a card that is sized 2GB or more. Format instructions are listed [here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).
+For SD cards, you will want a minimum of 128MB to run an exploit. On average, however, you will want a card that is sized 2GB or more. The Wii can read SD cards of any capacity (even those larger than 32GB), but the card must be formatted as FAR32 (**not** exFAT or NTFS). For instructions on properly formatting your SD card, [see here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).
 
 For USB devices, you will want to use a USB hard drive or solid state drive formatted as FAT32. We do not recommend using flash drives as they are prone to failure or not working as intended with a Wii.
 

--- a/docs/key-information.md
+++ b/docs/key-information.md
@@ -52,7 +52,7 @@ Be especially cautious with IOS to avoid bricking, since they are specifically d
 
 ## Storage Compatibility
 
-For SD cards, you will want a minimum of 128MB to run an exploit. On average, however, you will want a card that is sized 2GB or more. The Wii can read SD cards of any capacity (even those larger than 32GB), but the card must be formatted as FAR32 (**not** exFAT or NTFS). For instructions on properly formatting your SD card, [see here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).
+For SD cards, you will want a minimum of 128MB to run an exploit. On average, however, you will want a card that is sized 2GB or more. The Wii can read SD cards of any capacity (even those larger than 32GB), but the card must be formatted as FAT32 (**not** exFAT or NTFS). For instructions on properly formatting your SD card, [see here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card).
 
 For USB devices, you will want to use a USB hard drive or solid state drive formatted as FAT32. We do not recommend using flash drives as they are prone to failure or not working as intended with a Wii.
 

--- a/docs/str2hax.md
+++ b/docs/str2hax.md
@@ -2,6 +2,10 @@
 
 ::: warning
 
+Though str2hax allows you to install the Homebrew Channel on a Wii without an SD card, other vital steps later on (such as installing BootMii) still require an SD card.
+
+::: warning
+
 Note that if your ISP or networking environment prevents using custom DNS servers, str2hax will not work and you should [choose another exploit to use](get-started).
 
 :::

--- a/docs/wii-backups.md
+++ b/docs/wii-backups.md
@@ -105,7 +105,7 @@ If your disc was dumped to a FAT32 device, you should have gotten at least two f
 * A PC running MacOS or Linux
 * A USB drive or SD card
 * A dumped ISO from a Wii game disc
-* [Wii Backup Fusion](https://github.com/larsenv/Wii-Backup-Fusion)
+* [Wii Backup Fusion](https://github.com/larsenv/Wii-Backup-Fusion/releases)
 * [Wiimm's ISO Tools](https://wit.wiimm.de/download.html)
 
 ### Instructions

--- a/docs/wiiu-nand-dumper.md
+++ b/docs/wiiu-nand-dumper.md
@@ -10,7 +10,7 @@ If your Wii U side is already modded, proceed to [Installing the Homebrew Channe
 
 ::: info
 
-Your SD Card will need to be formatted as FAT32. If your SD Card is not formatted to FAT32, use [GUIFormat](http://ridgecrop.co.uk/index.htm?guiformat.htm) with 32k (32768) Allocation unit size to format it. **Do not** label the SD Card as `wiiu` or it will cause issues with homebrew.
+Your SD Card will need to be formatted as FAT32. If your SD Card is not formatted to FAT32, follow [this guide](https://wiki.hacks.guide/wiki/Formatting_an_SD_card) to format it. **Do not** label the SD Card as `wiiu` or it will cause issues with homebrew.
 
 
 ## Requirements

--- a/docs/wilbrand.md
+++ b/docs/wilbrand.md
@@ -18,7 +18,7 @@ Wilbrand Web is recommended for its ease of use.
 
 ### Requirements
 
-* An SD card formatted to FAT32/MS-DOS ([formatting guide here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card))
+* An SD card [formatted to FAT32/MS-DOS](https://wiki.hacks.guide/wiki/Formatting_an_SD_card)
 * A Wii on version 3.0 or newer
 
 ::: warning

--- a/docs/wilbrand.md
+++ b/docs/wilbrand.md
@@ -83,7 +83,7 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
 ### Requirements
 
 * A computer running Windows, macOS or Linux
-* An SD card formatted to FAT32/MS-DOS ([formatting guide here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card))
+* An SD card [formatted to FAT32/MS-DOS](https://wiki.hacks.guide/wiki/Formatting_an_SD_card)
 * A Wii on version 3.0 or newer
 * [Wilbrand](https://static.wiidatabase.de/Wilbrand.zip)
 * [HackMii Installer v1.2](https://bootmii.org/download/)

--- a/docs/wilbrand.md
+++ b/docs/wilbrand.md
@@ -18,7 +18,7 @@ Wilbrand Web is recommended for its ease of use.
 
 ### Requirements
 
-* An SD card formatted to FAT32/MS-DOS
+* An SD card formatted to FAT32/MS-DOS ([formatting guide here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card))
 * A Wii on version 3.0 or newer
 
 ::: warning
@@ -83,7 +83,7 @@ SD cards larger than 2GB will not work on Wii menu versions before 4.0.
 ### Requirements
 
 * A computer running Windows, macOS or Linux
-* An SD card formatted to FAT32/MS-DOS
+* An SD card formatted to FAT32/MS-DOS ([formatting guide here](https://wiki.hacks.guide/wiki/Formatting_an_SD_card))
 * A Wii on version 3.0 or newer
 * [Wilbrand](https://static.wiidatabase.de/Wilbrand.zip)
 * [HackMii Installer v1.2](https://bootmii.org/download/)


### PR DESCRIPTION
This pull request makes changes throughout the guide to make it clearer that formatting their SD card to FAT32 is required. It uses wording already present in the 3DS guide to convey this, and links to the Wiki page detailing how to do so.

Specifically, the changes are:
- Update vWii guide to link to the formatting guide instead of a direct link to GUIFormat
- Add note to str2hax informing the user that even if they intend to mod without an SD card, they will need one for future steps
- Update Wilbrand to have a link to the formatting guide
- Include additional info to the FAQ about formatting SD cards, as well as remove some outdated info
- Make it clearer in the Key Information section that cards must be formatted

(I also threw in a teeny change in the Wii Backup Fusion page)