### PR TITLE
Redirect wiimmfi.md to new page

### DIFF
--- a/docs/wiimmfi.md
+++ b/docs/wiimmfi.md
@@ -1,0 +1,8 @@
+---
+head:
+  - - meta
+    - http-equiv: refresh
+      content: '0; URL=nintendowfc.html'
+---
+
+# Redirecting


### PR DESCRIPTION
[Previous commit](https://github.com/mpgiii/Guide_Wii/commit/f4851d53bd5195a1384fdff659a897efdbdc66cd) renamed wiimmfi to nintendowfc -- this commit simply makes it so the old URL (if used elsewhere) redirects to the new one