### PR TITLE
Add note about legacy 802.11b rates

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -134,6 +134,7 @@ The Wii's wireless networking hardware supports the maximum standard of 802.11g 
 
 + APs enforcing WPA enterprise encryption, or WPA3 only
 + APs not backwards compatible with WiFi 3, or broadcasting only on the 5 GHz band
++ APs not supporting legacy 802.11b rates
 
 ISPs known to provide routers incompatible with these settings:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -134,7 +134,7 @@ The Wii's wireless networking hardware supports the maximum standard of 802.11g 
 
 + APs enforcing WPA enterprise encryption, or WPA3 only
 + APs not backwards compatible with WiFi 3, or broadcasting only on the 5 GHz band
-+ APs not supporting legacy 802.11b rates
++ APs not supporting legacy 802.11b or 802.11g rates (i.e. APs supporting only 802.11n)
 
 ISPs known to provide routers incompatible with these settings:
 


### PR DESCRIPTION
**Description**

Found this on https://gbatemp.net/threads/wii-wont-connect-to-wifi.557433/#post-8936892 and changing my OpenWrt 2.4Ghz channel to enable legacy 802.11b rates fixed my Wii being unable to connect to LAN exactly as described in the thread.
