### PR TITLE
Add a warning about letterbomb being obsolete

### DIFF
--- a/docs/letterbomb.md
+++ b/docs/letterbomb.md
@@ -1,5 +1,10 @@
 # LetterBomb
 
+::: warning
+LetterBomb has been obsoleted by [Wilbrand](wilbrand).
+
+:::
+
 LetterBomb is an exploit for the Wii that is triggered using the Wii Message Board.
 
 ::: info


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

A lot of people are coming from video guides and using LetterBomb still in 2025. It's not severely outdated as Wilbrand is the same thing with wider support, it's just that requiring to update to 4.3 is unnecessary.