### PR TITLE
Add clarity to vWii guide

### DIFF
--- a/docs/bricks.md
+++ b/docs/bricks.md
@@ -188,7 +188,7 @@ You can either restore a NAND backup, or do this:
 1. Use [NUS Downloader](https://wiibrew.org/wiki/NUSD) to pack a WAD of your original Wii Menu.
 1. Use BootMii to enter the Homebrew Channel, and use a WAD manager to install the Wii Menu WAD.
 
-For vWii, See [Recover a vWii IOS/Channel](https://wiiu.hacks.guide/#/recover-vwii-ioses-channels)
+For vWii, See [Recover a vWii IOS/Channel](https://wiiu.hacks.guide/recover-vwii-ioses-channels)
 
 ## Wi-Fi brick
 

--- a/docs/priiloader.md
+++ b/docs/priiloader.md
@@ -14,7 +14,7 @@ Additionally, it can be used to quickly launch any Title or Homebrew, or change 
 
 * An SD card
 * [Priiloader Wii U Forwarder](https://github.com/DacoTaco/priiloader/releases/download/0.10.0/PriiloaderWiiUForwarder.zip) (direct download)
-    * [Aroma](https://wiiu.hacks.guide/#/aroma/getting-started) must be installed on your console for Priiloader Wii U Forwarder to function.
+    * [Aroma](https://wiiu.hacks.guide/aroma/getting-started) must be installed on your console for Priiloader Wii U Forwarder to function.
 
 ## Instructions
 

--- a/docs/priiloader.md
+++ b/docs/priiloader.md
@@ -14,7 +14,7 @@ Additionally, it can be used to quickly launch any Title or Homebrew, or change 
 
 * An SD card
 * [Priiloader Wii U Forwarder](https://github.com/DacoTaco/priiloader/releases/download/0.10.0/PriiloaderWiiUForwarder.zip) (direct download)
-    * [Aroma](https://wiiu.hacks.guide/aroma/getting-started) must be installed on your console for Priiloader Wii U Forwarder to function.
+    * [Aroma](https://wiiu.hacks.guide/aroma/getting-started) must be installed on your console for the Priiloader Wii U Forwarder to function.
 
 ## Instructions
 

--- a/docs/vwii-homebrew-channel.md
+++ b/docs/vwii-homebrew-channel.md
@@ -12,9 +12,9 @@ If you have hacked your Wii U in the past, you can use the same SD Card for this
 
 ::: info
 
-If you haven't already, make sure you did a [NAND backup](https://wiiu.hacks.guide/#/aroma/nand-backup) and have the [Aroma Environment](https://aroma.foryour.cafe/) installed on your Wii U.
+If you haven't already, make sure you did a [NAND backup](https://wiiu.hacks.guide/aroma/nand-backup) and have the [Aroma Environment](https://aroma.foryour.cafe/) installed on your Wii U.
 
-Otherwise, proceed to [Installing Aroma](https://wiiu.hacks.guide/#/aroma/getting-started) or [Modding the vWii without modding the Wii U side](wiiu-nand-dumper)
+Otherwise, proceed to [Installing Aroma](https://wiiu.hacks.guide/aroma/getting-started) or [Modding the vWii without modding the Wii U side](wiiu-nand-dumper)
 
 :::
 
@@ -38,12 +38,15 @@ If the evWii Aroma plugin is not installed, and a homebrew app hangs, the only w
 1. Insert your Wii U's SD Card into your PC.
 1. Copy the contents of the `CompatTitleInstaller.zip` file to the root of your SD Card.
 1. Copy the contents of the `evWii.zip` file to the root of your SD Card.
+1. Re-insert your SD card into the Wii U.
 
 ### Section II - Installing the Homebrew Channel
 
-1. Boot into [Aroma](https://wiiu.hacks.guide/#/aroma/finalizing-setup).
-1. Launch the vWii Compat Installer on the Wii U menu.
+1. Boot into [Aroma](https://wiiu.hacks.guide/aroma/finalizing-setup).
+    + If you set up [Aroma autobooting](https://wiiu.hacks.guide/aroma/autobooting), Aroma will be already be running when you turn on your console.
+1. Launch the vWii Compat Installer app from the Wii U menu.
 1. Press `A` to install the Homebrew Channel and wait until you see `Install succeeded`. Then press the HOME button to return to the Wii U Menu.
+    + If the HOME button doesn't work, you can safely power off by holding down the power button on your console, and then turn it back on.
 1. Launch vWii (the Wii Menu icon).
     + If the installation has succeeded, you should see the Homebrew Channel in your Wii Menu.
 
@@ -67,7 +70,7 @@ Note: When installing Wii homebrew applications on your SD Card or USB drive, yo
 ```
 
 `AppName1` and `AppName2` are placeholder names. Do not nest multiple `apps` folders inside the `apps` folder itself.
-Do not Get confused with the `apps` folder inside of the `wiiu` folder and the `apps` folder on the root of the SD card.
+Note that the `apps` folder inside of the `wiiu` folder (for Wii U homebrew apps) and the `apps` folder on the root of the SD card (for Wii homebrew apps) are distinct.
 
 ::: tip
 

--- a/docs/vwii-homebrew-channel.md
+++ b/docs/vwii-homebrew-channel.md
@@ -43,7 +43,7 @@ If the evWii Aroma plugin is not installed, and a homebrew app hangs, the only w
 ### Section II - Installing the Homebrew Channel
 
 1. Boot into [Aroma](https://wiiu.hacks.guide/aroma/finalizing-setup).
-    + If you set up [Aroma autobooting](https://wiiu.hacks.guide/aroma/autobooting), Aroma will be already be running when you turn on your console.
+    + If you set up [Aroma autobooting](https://wiiu.hacks.guide/aroma/autobooting), Aroma will already be running when you turn on your console.
 1. Launch the vWii Compat Installer app from the Wii U menu.
 1. Press `A` to install the Homebrew Channel and wait until you see `Install succeeded`. Then press the HOME button to return to the Wii U Menu.
     + If the HOME button doesn't work, you can safely power off by holding down the power button on your console, and then turn it back on.


### PR DESCRIPTION
This change simply adjusts some grammar and adds some additional call-outs to the vWii portion of the guide.

It also sweeps through the repo and fixes links to wiiu.hacks.guide that still had `/#/` in them, which is no longer the correct path and would redirect users to the main page.