### PR TITLE
Add CleanURLS to remove the .html from the page url

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -34,6 +34,7 @@ export default defineConfig({
       { icon: 'github', link: 'https://github.com/hacks-guide/Guide_Wii' }
     ]
   },
+  cleanUrls: true
   vite: {
     resolve: {
       alias: [


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

This PR updates the site to use clean URLs by removing the .html extension from page links. It makes the URLs look nicer and a bit more user-friendly. Also helps a bit with SEO and keeps things consistent with modern web standards.