### PR TITLE
Update gc-backups.md

### DIFF
--- a/docs/gc-backups.md
+++ b/docs/gc-backups.md
@@ -4,6 +4,7 @@ This guide provides instructions on how to manage your GameCube backups, using G
 
 ## Requirements
 
+* A Windows PC
 * An SD card or USB drive
 * [GameCube Backup Manager](https://github.com/AxionDrak/GameCube-Backup-Manager/releases)
 


### PR DESCRIPTION
**Description**

The Wii Backups section of the guide specifies you need a windows PC to use Wii Backup Manager, however the GC version doesn't even though you need a windows PC to run GameCube backup manager.
