### PR TITLE
NAND backup in Dolphin is optional

### DIFF
--- a/docs/bootmii.md
+++ b/docs/bootmii.md
@@ -105,7 +105,7 @@ You can also use the [BootMii Config Editor](https://oscwii.org/library/app/Boot
 
 :::
 
-## Uploading NAND Backup to Dolphin Emulator (optional)
+## Uploading NAND Backup to Dolphin Emulator
 
 Your NAND backup can be utilized in Dolphin Emulator. This is completely optional.
 


### PR DESCRIPTION
helpee just thought it was mandatory lol