### PR TITLE
Only recommend 4.3 on Wii Factory Reset

### DIFF
--- a/docs/wii-factory-reset.md
+++ b/docs/wii-factory-reset.md
@@ -58,7 +58,7 @@ If you are trying to [update your Wii to 4.3U](update) with homebrew or update o
 
     ![](/images/factory-reset/formatnand.png)
 
-1. Select the top left text box in the program and type in the Wii System Menu version that you need the NAND to have. Note that this should optimally 4.3 (examples: `4.3E`, `4.3U`, `4.3J`, `4.3K`).
+1. Select the top left text box in the program and type in the Wii System Menu version that you need the NAND to have. Note that this should optimally be 4.3 (examples: `4.3E`, `4.3U`, `4.3J`, `4.3K`).
 
     ![](/images/factory-reset/sysmenu.png)
 


### PR DESCRIPTION
A helpee bricked their Wii because they saw 3.2, and ended up typing it, and since their Wii was a 4 layer Wii (way newer than RVL-CPU-20), it is unable to boot due to the simplified power circuitry. There is no reason to use an older version with this guide anyways.

**Description**

<!--What does this pull request do? Why is it needed?-->
