### PR TITLE
doc: remove 64-bit windows requirement for TinyWiiBackupManager

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -179,7 +179,7 @@ If you already have games on your drive and TinyWiiBackupManager prompts you to 
 
 #### Requirements
 
-* A PC running Linux which supports AppImage or Flatpak
+* A PC running Linux that supports AppImage or Flatpak
 * A USB drive or SD card
 * A dumped Wii/GameCube game disc (any format)
 * [TinyWiiBackupManager](https://github.com/mq1/TinyWiiBackupManager/releases/latest) 


### PR DESCRIPTION
TinyWiiBackupManager is also available for 32-bit PCs