### PR TITLE
cIOS/Priiloader: Small Tweaks

### DIFF
--- a/docs/cios.md
+++ b/docs/cios.md
@@ -47,7 +47,7 @@ If you are able to connect your Wii to the internet, you may skip to [Section II
 1. Power off your console, and insert your SD card or USB drive into your computer.
 1. On your computer, download [NUSGet](https://github.com/NinjaCheetah/NUSGet/releases/latest/), choosing the archive corresponding to your operating system. For Windows users, you should choose the `NUSGet-Windows-x86_64-bin.zip` file.
 1. Unzip the archive and run the NUSGet executable.
-1. Navigate to `IOS` -> `IOS 38` -> `World` and select `v4123`. Uncheck `Keep encrypted contents`, then click `Start Download`.
+1. Navigate to `IOS` -> `IOS 38` -> `World` and double click on `v4123`. Uncheck `Keep encrypted contents`, then click `Start Download`.
 
     ![](/images/desktop-apps/nusget/nusget-4123.png)
 1. Repeat the above step for `IOS 56 (v5661)`, `IOS 57 (v5918)` and `IOS 58 (v6175)`.
@@ -232,7 +232,7 @@ If you are able to connect your vWii to the internet, you may skip to [Section I
 1. Power off your console, and insert your SD card or USB drive into your computer.
 1. On your computer, download [NUSGet](https://github.com/NinjaCheetah/NUSGet/releases/latest/), choosing the archive corresponding to your operating system. For Windows users, you should choose the `NUSGet-Windows-x86_64-bin.zip` file.
 1. Unzip the archive and run the NUSGet executable.
-1. Select the `vWii` platform, navigate to `IOS` -> `IOS 38` -> `World` and select `v4380`. Uncheck `Keep encrypted contents`. Check `Re-encrypt title using the Wii Common Key`, then click `Start Download`.
+1. Select the `vWii` platform, navigate to `IOS` -> `IOS 38` -> `World` and double click on `v4380`. Uncheck `Keep encrypted contents`. Check `Re-encrypt title using the Wii Common Key`, then click `Start Download`.
 
     ![](/images/desktop-apps/nusget/nusget-4380.png)
 1. Repeat the above step for `IOS 56 (v5918)`, `IOS 57 (v6175)` and `IOS 58 (v6432)`.

--- a/docs/priiloader.md
+++ b/docs/priiloader.md
@@ -90,6 +90,7 @@ Doing so will cause Priiloader to fail to find the `hacks_hash.ini` file.
 
 1. Scroll down to `save settings` and press A.
 1. Press `B` to return to the main menu.
+1. Select "System Menu" to go back to the Wii Menu.
 
 ---
 


### PR DESCRIPTION
**Description**

- Mention on the cIOS guide that you explicitly need to double click on a IOS version to select it in NUSGet, since some users have shown confusion when they just click on the IOS and nothing happens.
- Mention on the Priiloader guide how to go back to the Wii Menu after setting up the hacks, since it's not clear at first glance what you should do after that step due to the guide ending while you are still in Priiloader.
