### PR TITLE
Fix a small typo in the WiiU NAND backup guide

### DIFF
--- a/docs/wiiu-nand-dumper.md
+++ b/docs/wiiu-nand-dumper.md
@@ -1,6 +1,6 @@
 # Creating a NAND Backup (Wii U)
 
-In order to protect your Wii U from permanant bricks, this guide will instruct you on how to create a NAND backup.
+In order to protect your Wii U from permanent bricks, this guide will instruct you on how to create a NAND backup.
 
 ::: tip
 


### PR DESCRIPTION
I spotted a typo in the WiiU NAND backup page so I fixed it :) (permanant -> permanent)