### PR TITLE
Add alt. suggestions for Wiimmfi Secondary DNS

### DIFF
--- a/docs/nintendowfc.md
+++ b/docs/nintendowfc.md
@@ -108,7 +108,9 @@ A method for Wiimmfi patching which runs on retail game discs automatically thro
 
 #### Instructions
 
-1. Go to `Wii Settings` -> `Internet` -> `Connection Settings` and select whatever connection you are using. Then, `Change Settings` -> `Auto-Obtain DNS NO` -> `Advanced Settings`. Set your primary DNS to `95.217.77.181`, and your secondary DNS to `1.1.1.1`.
+1. Go to `Wii Settings` -> `Internet` -> `Connection Settings` and select whatever connection you are using. Then, `Change Settings` -> `Auto-Obtain DNS NO` -> `Advanced Settings`. Set your DNS to the following:
+   * Primary DNS: `95.217.77.181`
+   * Secondary DNS: `1.1.1.1` (Cloudflare)
 1. Let the connection test finish, and do not perform a Wii System Update.
 1. Launch your game through the Disc Channel - it should now be patched with Wiimmfi.
 
@@ -117,6 +119,8 @@ A method for Wiimmfi patching which runs on retail game discs automatically thro
 If you get error `20100` or `20110`, the game you are trying to play is not supported by this method.
 
 If you get error `23400`, your ISP or network is blocking the use of a custom DNS. To resolve this issue, Wiimmfi has a custom DNS server that can be ran on your PC - you can read about it [on the Wiimmfi website](https://wiimmfi.de/patcher/dnspatch#customdns).
+
+If you find that you are having odd issues with the Secondary DNS, you could try changing to another provider. We recommend either `8.8.8.8` (Google) OR `9.9.9.9` (Quad9).
 
 :::
 


### PR DESCRIPTION
This PR adds alternate suggestions for the Secondary DNS in the Custom DNS disc patching section of the Nintendo WFC guide for Wiimmfi. Specifically, Google DNS `8.8.8.8` and Quad9 DNS `9.9.9.9` are given as alternatives, in the event of any trouble with Cloudflare that may otherwise impact normal operation.

Closes #197.