### PR TITLE
[bootmiirecover.md] Fix the steps skipped for bootmii @ boot2 users.

### DIFF
--- a/docs/bootmiirecover.md
+++ b/docs/bootmiirecover.md
@@ -10,7 +10,7 @@ Please read the information below before proceeding further.
 
 * Family Edition Wiis and Wii minis **CANNOT** restore NAND backups. This is because of the lack of GameCube ports which are required on non-boot2 Wiis to enter the restoration confirmation code. For additional help, please seek support on the [Nintendo Homebrew discord server](https://discord.gg/C29hYvh).
 
-* If you have BootMii installed as boot2, you will need to launch BootMii by restarting the console. Skip steps 1 and 2 if this is the case.
+* If you have BootMii installed as boot2, you will need to launch BootMii by restarting the console. Skip steps 4 and 5 if this is the case.
 
 * If you have not done anything to cause a brick (or you're starting up your Wii after a long time), then it is likely a [Wi-Fi Brick](bricks#wi-fi-brick).
 


### PR DESCRIPTION
Before #208 was merged, bootmii @ boot2 users were told to skip steps 1 and 2 as they access bootmii by restarting this console. When the PR was merged, steps 1 and 2 became copying the backup from PC to the sd if it wasn't already there, however I forgot to update the info box.

Changing the information in the box from steps 1 and 2 to steps 4 and 5 fixes this issue.