### PR TITLE
Fix letterbomb compatibility info for vWii

### DIFF
--- a/docs/legacy-exploits.md
+++ b/docs/legacy-exploits.md
@@ -13,7 +13,7 @@ This page lists different exploits that were/can still be used on the Wii and vW
 ### Letterbomb (Wii / Family Edition only)
 
 * Crashes the Wii Menu by exploiting an oversight in the Wii Message Board.
-* Works on Wii system menu version 4.3 ONLY. on vWii, there is no access to Wii system settings.
+* Works on Wii system menu version 4.3 ONLY. Letterbomb is not compatible with the vWii because there is no access to Wii system settings.
 * Superseded by Wilbrand, functionality remains the same but Wilbrand has wider support. May be considered when Wilbrand does not work.
 * [WiiBrew Page](https://wiibrew.org/wiki/LetterBomb)
 


### PR DESCRIPTION
**Description**

The vWii info for letterbomb in it's current state looks like someone forgot to finish the sentence. There is no capital letter after the full stop and it feels like just a random thought and it doesn't really flow well. This PR aims to make it fit in more and feel like relevant information.