### PR TITLE
Add a warning for people restoring their Wii NAND to stock for no good reason

### DIFF
--- a/docs/wii-factory-reset.md
+++ b/docs/wii-factory-reset.md
@@ -33,6 +33,7 @@ If you are formatting your Wii because:
 * You want to update your System Menu version
 
 <u>**STOP!!!**</u> Formatting your Wii is an unnecessary risk that will at best waste your time and at worst [**BRICK**](bricks#low-level-brick) your console!
+
 :::
 
 ::: warning

--- a/docs/wii-factory-reset.md
+++ b/docs/wii-factory-reset.md
@@ -18,6 +18,9 @@ The instructions detailed in this guide **WILL ERASE YOUR WII SYSTEM MEMORY** an
 * Fix a brick where you do not have a functional NAND backup or access to the Homebrew Channel but can still make one using BootMii.
 * You are unable to revert certain changes to the Wii System Memory such as all cIOS with DARKCORP.
 
+:::
+
+::: danger
 If you are formatting your Wii because:
 * You want to re-mod it
 * You want to update outdated homebrew and/or cIOS
@@ -29,10 +32,6 @@ If you are formatting your Wii because:
 * You want to update your System Menu version
 
 <u>**STOP!!!**</u> Formatting your Wii is an unnecessary risk that will at best waste your time and at worst [**BRICK**](bricks#low-level-brick) your console!
-
-:::
-
-::: warning
 
 If you are trying to [update your Wii to 4.3U](update) with homebrew or update outdated homebrew/IOS, you most likely do not need to follow this guide. Instead, you can use a tool like the SysCheck Updater Wizard built into [ModMii](modmii#syscheck-updater-wizard). If you are confused about this process, consider joining the [Nintendo Homebrew Discord](https://discord.gg/C29hYvh) and going to the `#wii-vwii-assistance` channel.
 

--- a/docs/wii-factory-reset.md
+++ b/docs/wii-factory-reset.md
@@ -18,10 +18,6 @@ The instructions detailed in this guide **WILL ERASE YOUR WII SYSTEM MEMORY** an
 * Fix a brick where you do not have a functional NAND backup or access to the Homebrew Channel but can still make one using BootMii.
 * You are unable to revert certain changes to the Wii System Memory such as all cIOS with DARKCORP.
 
-:::
-
-::: danger
-
 If you are formatting your Wii because:
 * You want to re-mod it
 * You want to update outdated homebrew and/or cIOS
@@ -29,7 +25,7 @@ If you are formatting your Wii because:
 * Your SD card was lost or corrupted
 * One of your games is broken
 * One of your homebrew applications is broken
-* Your console is unable to boot to System Menu
+* Your console is unable to boot to the System Menu
 * You want to update your System Menu version
 
 <u>**STOP!!!**</u> Formatting your Wii is an unnecessary risk that will at best waste your time and at worst [**BRICK**](bricks#low-level-brick) your console!

--- a/docs/wii-factory-reset.md
+++ b/docs/wii-factory-reset.md
@@ -21,6 +21,7 @@ The instructions detailed in this guide **WILL ERASE YOUR WII SYSTEM MEMORY** an
 :::
 
 ::: danger
+
 If you are formatting your Wii because:
 * You want to re-mod it
 * You want to update outdated homebrew and/or cIOS

--- a/docs/wii-factory-reset.md
+++ b/docs/wii-factory-reset.md
@@ -12,12 +12,27 @@ Do not attempt this tutorial on the Wii U's vWii.
 
 ::: danger
 
-The instructions detailed in this guide WILL ERASE YOUR WII SYSTEM MEMORY and should only be considered as a LAST RESORT or if you are trying to do any of the following:
+The instructions detailed in this guide **WILL ERASE YOUR WII SYSTEM MEMORY** and should only be considered as a **LAST RESORT** or if you are trying to do any of the following:
 
 * Restore the Wii to a state comparable to when it left the factory.
 * Fix a brick where you do not have a functional NAND backup or access to the Homebrew Channel but can still make one using BootMii.
 * You are unable to revert certain changes to the Wii System Memory such as all cIOS with DARKCORP.
 
+:::
+
+::: danger
+
+If you are formatting your Wii because:
+* You want to re-mod it
+* You want to update outdated homebrew and/or cIOS
+* You want to change SD cards
+* Your SD card was lost or corrupted
+* One of your games is broken
+* One of your homebrew applications is broken
+* Your console is unable to boot to System Menu
+* You want to update your System Menu version
+
+<u>**STOP!!!**</u> Formatting your Wii is an unnecessary risk that will at best waste your time and at worst [**BRICK**](bricks#low-level-brick) your console!
 :::
 
 ::: warning


### PR DESCRIPTION
**Description**

I feel it needs to be stated, similar to what’s on the 3ds guide’s uninstalling CFW page, that restoring your Wiis nand to stock comes with a small amount of brick risk and shouldn’t be done for no good reason.